### PR TITLE
feat: support NU6.3 (Ironwood)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin 0.9.8",
 ]
 
@@ -1048,8 +1049,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1475,7 +1478,7 @@ dependencies = [
  "hyper 1.10.1",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1890,6 +1893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3233,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
  "bitflags 2.10.0",
  "either",
@@ -4892,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -4906,17 +4918,17 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
+version = "0.24.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "base64 0.22.1",
  "bech32",
  "bip32",
  "bls12_381",
  "bs58",
- "crossbeam-channel",
  "document-features",
+ "flume",
  "getset",
  "group",
  "hex",
@@ -4936,7 +4948,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
@@ -4967,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "bip32",
@@ -5009,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5040,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5062,9 +5073,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -5101,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -5232,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bls12_381 = "0.8"
 jubjub = "0.10"
 ff = "0.13"
 group = "0.13"
-orchard = "0.14.0"
+orchard = "0.15"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
@@ -49,16 +49,21 @@ sapling-crypto = "0.7"
 zcash_note_encryption = "0.4.1"
 zip32 = "0.2"
 
-zcash_client_backend = { version = "0.23", features = [
+# NU6.3 (Ironwood) support: the librustzcash "ironwood" line, consumed from crates.io. The
+# leaf crates are finals; the wallet crates are still release candidates — move these reqs to
+# the finals once they publish. Ironwood is *not* a cargo feature: the published line exposes
+# the ironwood APIs unconditionally, and activation is purely consensus-height driven
+# (`NetworkUpgrade::Nu6_3`), so a plain `cargo build` is NU6.3-ready on every network.
+zcash_client_backend = { version = "0.24.0-rc.4", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "transparent-inputs",
 ] }
-zcash_keys = { version = "0.14", features = ["orchard", "sapling"] }
-zcash_protocol = { version = "0.9", features = ["local-consensus"] }
-zcash_address = { version = "0.12" }
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
+zcash_keys = { version = "0.16", features = ["orchard", "sapling"] }
+zcash_protocol = { version = "0.10", features = ["local-consensus"] }
+zcash_address = { version = "0.13" }
+zcash_primitives = "0.30"
+zcash_proofs = "0.30"
 
 [build-dependencies]
 tonic-build = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`zcash-walletd` is a shielded only (sapling, orchard, UA) REST wallet
+`zcash-walletd` is a shielded only (sapling, orchard, ironwood, UA) REST wallet
 for zcash.
 
 Primary intended to work with the BTCPayServer payment gateway,
@@ -58,3 +58,29 @@ The latest image is available on DockerHub under `hhanh00/zcash-walletd:latest`
 ## Orchard
 Support for Orchard and UA was added in 1.1.2. You MUST delete the database file
 because the previous schema is not compatible.
+
+## NU6.3 (Ironwood)
+
+NU6.3 introduces the **Ironwood** shielded pool. Ironwood reuses Orchard's keys, addresses and
+action encoding, so **no new address type and no re-issuing of addresses is needed**: an
+Ironwood note is received at an ordinary Orchard receiver of a UA. What differs is that
+Ironwood notes use their own note-plaintext version and live in their own commitment tree, and
+that **once NU6.3 activates, payments to an Orchard receiver are routed to the Ironwood pool**.
+A wallet that scans only the Orchard bundle therefore stops seeing its own incoming payments
+after activation.
+
+`zcash-walletd` scans both pools. Two things are required of the deployment:
+
+- **Upgrade `lightwalletd`.** Ironwood data only rides in compact blocks when the client asks
+  for it via `BlockRange.poolTypes`, which is part of the versioned
+  [lightwallet-protocol](https://github.com/zcash/lightwallet-protocol). `zcash-walletd`
+  requests it only from a server that advertises `LightdInfo.lightwalletProtocolVersion`, since
+  a legacy server may reject or misinterpret the field. Against a legacy (<= v0.4.x) server it
+  falls back to the Sapling + Orchard default and logs a warning — correct before activation,
+  but Ironwood receives will be **invisible** after it. Upgrade the server before the NU6.3
+  activation height.
+- **No database reset is needed.** The `received_notes` table gains a `pool` column on first
+  start (note positions are only unique within a pool's own commitment tree, and Ironwood's
+  restarts at zero); the migration runs automatically and preserves existing rows.
+
+Activation is consensus-height driven — there is no build flag and no configuration switch.

--- a/proto/compact_formats.proto
+++ b/proto/compact_formats.proto
@@ -40,6 +40,11 @@ message CompactTx {
     repeated CompactSaplingSpend spends = 4;   // inputs
     repeated CompactSaplingOutput outputs = 5; // outputs
     repeated CompactOrchardAction actions = 6;
+    // Actions of the Ironwood (NU6.3) bundle. Ironwood reuses Orchard's action encoding and
+    // keys, but its notes live in a *separate* commitment tree and use the V3 note-plaintext
+    // lead byte, so they must be trial-decrypted with the Ironwood note-encryption domain and
+    // positioned against the Ironwood tree. Only populated by versioned-protocol servers.
+    repeated CompactOrchardAction ironwoodActions = 9;
 }
 
 // CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -15,12 +15,28 @@ message BlockID {
      bytes hash = 2;
 }
 
+// An identifier for a Zcash value pool.
+enum PoolType {
+    POOL_TYPE_INVALID = 0;
+    TRANSPARENT = 1;
+    SAPLING = 2;
+    ORCHARD = 3;
+    IRONWOOD = 4;
+}
+
 // BlockRange specifies a series of blocks from start to end inclusive.
 // Both BlockIDs must be heights; specification by hash is not yet supported.
+//
+// `poolTypes` selects which value pools the server should include in the returned
+// compact blocks. It is part of the *versioned* lightwallet-protocol
+// (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
+// advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
+// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
+// legacy default (Sapling + Orchard only).
 message BlockRange {
     BlockID start = 1;
     BlockID end = 2;
-    uint64 spamFilterThreshold = 3;
+    repeated PoolType poolTypes = 3;
 }
 
 // A TxFilter contains the information needed to identify a particular
@@ -71,6 +87,13 @@ message LightdInfo {
     uint64 estimatedHeight = 12;        // less than tip height if zcashd is syncing
     string zcashdBuild = 13;            // example: "v4.1.1-877212414"
     string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
+    string donationAddress = 15;        // Zcash donation UA address
+    string upgradeName = 16;            // name of next pending network upgrade, empty if none scheduled
+    uint64 upgradeHeight = 17;          // height of next pending upgrade, zero if none is scheduled
+    // Version of https://github.com/zcash/lightwallet-protocol served by this server.
+    // Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
+    // (and hence Ironwood data in compact blocks).
+    string lightwalletProtocolVersion = 18;
 }
 
 // TransparentAddressBlockFilter restricts the results to the given address
@@ -117,6 +140,7 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood (NU6.3) commitment tree state
 }
 
 // Results are sorted by height, which makes it easy to issue another

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use crate::account::{Account, AccountBalance, SubAccount};
 use crate::lwd_rpc::BlockId;
 use crate::network::Network;
-use crate::scan::ScanEvent;
+use crate::scan::{ScanEvent, POOL_ORCHARD, POOL_SAPLING};
 use crate::transaction::{SubAddress, Transfer};
 use crate::{notify_tx, Client, Hash};
 use anyhow::Result;
@@ -14,6 +14,26 @@ use zcash_keys::address::UnifiedAddress;
 use zcash_keys::encoding::AddressCodec;
 use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+/// Schema of `received_notes`. Kept in one place because the pool migration rebuilds the table
+/// from it (SQLite cannot alter a table constraint in place).
+const RECEIVED_NOTES_DDL: &str = "CREATE TABLE IF NOT EXISTS received_notes (
+    id_note INTEGER PRIMARY KEY,
+    address TEXT NOT NULL,
+    account INTEGER,
+    sub_account INTEGER,
+    id_tx INTEGER NOT NULL,
+    pool INTEGER NOT NULL,
+    position INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    diversifier BLOB NOT NULL,
+    value INTEGER NOT NULL,
+    rcm BLOB NOT NULL,
+    nf BLOB NOT NULL UNIQUE,
+    rho BLOB,
+    memo TEXT,
+    spent INTEGER,
+    CONSTRAINT tx_output UNIQUE (pool, position))";
 
 pub struct Db {
     network: Network,
@@ -41,6 +61,57 @@ impl Db {
             notify_tx_url: notify_tx_url.to_string(),
             address_creation_lock: Mutex::new(()),
         })
+    }
+
+    /// Migrate a pre-NU6.3 `received_notes` table to the pool-aware schema.
+    ///
+    /// Note positions are only unique *within* a pool's commitment tree, and Ironwood's tree
+    /// starts from zero when NU6.3 activates — so its early positions collide head-on with the
+    /// low Sapling/Orchard positions a wallet may already hold, and the old
+    /// `UNIQUE (position)` constraint would reject the insert and wedge the scan. Record the
+    /// note's pool and key the constraint on `(pool, position)` instead.
+    ///
+    /// SQLite can't alter a table constraint in place, so rebuild the table. The pool of an
+    /// existing row is recoverable without rescanning: `rho` is only ever set for
+    /// Orchard-family notes, so a NULL `rho` means Sapling. No pre-migration row can be
+    /// Ironwood — the pool did not exist.
+    async fn migrate_received_notes_pool(connection: &mut SqliteConnection) -> Result<()> {
+        if sqlx::query("SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'pool'")
+            .fetch_optional(&mut *connection)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        log::info!("Migrating received_notes to the pool-aware (NU6.3) schema");
+
+        let mut db_transaction = connection.begin().await?;
+        let db_tx = db_transaction.acquire().await?;
+        sqlx::query(&RECEIVED_NOTES_DDL.replace("received_notes", "received_notes_new"))
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query(
+            "INSERT INTO received_notes_new
+            (id_note, address, account, sub_account, id_tx, pool, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            SELECT id_note, address, account, sub_account, id_tx,
+            CASE WHEN rho IS NULL THEN ?1 ELSE ?2 END,
+            position, height, diversifier, value, rcm, nf, rho, memo, spent
+            FROM received_notes",
+        )
+        .bind(POOL_SAPLING)
+        .bind(POOL_ORCHARD)
+        .execute(&mut *db_tx)
+        .await?;
+        sqlx::query("DROP TABLE received_notes")
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query("ALTER TABLE received_notes_new RENAME TO received_notes")
+            .execute(&mut *db_tx)
+            .await?;
+        db_transaction.commit().await?;
+
+        Ok(())
     }
 
     async fn cleanup_stale_data(connection: &mut SqliteConnection) -> Result<()> {
@@ -433,26 +504,9 @@ impl Db {
         .execute(&mut *connection)
         .await?;
 
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS received_notes (
-            id_note INTEGER PRIMARY KEY,
-            address TEXT NOT NULL,
-            account INTEGER,
-            sub_account INTEGER,
-            id_tx INTEGER NOT NULL,
-            position INTEGER NOT NULL,
-            height INTEGER NOT NULL,
-            diversifier BLOB NOT NULL,
-            value INTEGER NOT NULL,
-            rcm BLOB NOT NULL,
-            nf BLOB NOT NULL UNIQUE,
-            rho BLOB,
-            memo TEXT,
-            spent INTEGER,
-            CONSTRAINT tx_output UNIQUE (position))",
-        )
-        .execute(&mut *connection)
-        .await?;
+        sqlx::query(RECEIVED_NOTES_DDL)
+            .execute(&mut *connection)
+            .await?;
 
         Self::cleanup_stale_data(&mut connection).await?;
 
@@ -463,6 +517,8 @@ impl Db {
         {
             panic!("Old database schema. This version is not compatible with it.");
         }
+
+        Self::migrate_received_notes_pool(&mut connection).await?;
 
         let r = sqlx::query("SELECT 1 FROM addresses")
             .map(|r: SqliteRow| r.get::<u32, _>(0))
@@ -556,14 +612,15 @@ impl Db {
 
                     sqlx::query(
                         "INSERT INTO received_notes
-                        (address, account, sub_account, id_tx, position, height,
+                        (address, account, sub_account, id_tx, pool, position, height,
                         diversifier, value, rcm, nf, rho, memo, spent)
-                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,'',0)",
+                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,'',0)",
                     )
                     .bind(&received_note.address)
                     .bind(account)
                     .bind(sub_account)
                     .bind(id_tx)
+                    .bind(received_note.pool)
                     .bind(received_note.position)
                     .bind(received_note.height)
                     .bind(received_note.diversifier.as_slice())
@@ -661,5 +718,118 @@ impl Db {
 
     pub fn ufvk(&self) -> &UnifiedFullViewingKey {
         &self.ufvk
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::POOL_IRONWOOD;
+    use sqlx::Connection;
+
+    /// The pre-NU6.3 `received_notes` schema: no `pool` column, and note positions constrained
+    /// to be unique across every pool.
+    const LEGACY_DDL: &str = "CREATE TABLE received_notes (
+        id_note INTEGER PRIMARY KEY,
+        address TEXT NOT NULL,
+        account INTEGER,
+        sub_account INTEGER,
+        id_tx INTEGER NOT NULL,
+        position INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        diversifier BLOB NOT NULL,
+        value INTEGER NOT NULL,
+        rcm BLOB NOT NULL,
+        nf BLOB NOT NULL UNIQUE,
+        rho BLOB,
+        memo TEXT,
+        spent INTEGER,
+        CONSTRAINT tx_output UNIQUE (position))";
+
+    async fn insert_legacy_note(
+        connection: &mut SqliteConnection,
+        position: u32,
+        nf: &[u8],
+        rho: Option<&[u8]>,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO received_notes
+            (address, account, sub_account, id_tx, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            VALUES ('addr',0,0,1,?1,100,x'00',1000,x'00',?2,?3,'',0)",
+        )
+        .bind(position)
+        .bind(nf)
+        .bind(rho)
+        .execute(&mut *connection)
+        .await?;
+        Ok(())
+    }
+
+    async fn insert_note(
+        connection: &mut SqliteConnection,
+        pool: u8,
+        position: u32,
+        nf: &[u8],
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO received_notes
+            (address, account, sub_account, id_tx, pool, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            VALUES ('addr',0,0,1,?1,?2,100,x'00',1000,x'00',?3,NULL,'',0)",
+        )
+        .bind(pool)
+        .bind(position)
+        .bind(nf)
+        .execute(&mut *connection)
+        .await?;
+        Ok(())
+    }
+
+    /// The migration must (a) recover each existing note's pool without a rescan and (b) key the
+    /// uniqueness constraint on `(pool, position)`. Ironwood's commitment tree restarts note
+    /// positions from zero at the NU6.3 activation height, so under the legacy
+    /// `UNIQUE (position)` constraint the first Ironwood receives would collide with the
+    /// wallet's low Sapling/Orchard positions and fail the whole scan batch.
+    #[tokio::test]
+    async fn migration_backfills_pools_and_rekeys_the_position_constraint() -> Result<()> {
+        let mut connection = SqliteConnection::connect("sqlite::memory:").await?;
+        sqlx::query(LEGACY_DDL).execute(&mut connection).await?;
+        // `rho` is set only on Orchard-family notes, which is what makes the pool of a
+        // pre-migration row recoverable.
+        insert_legacy_note(&mut connection, 7, b"sapling-nf", None).await?;
+        insert_legacy_note(&mut connection, 9, b"orchard-nf", Some(b"rho")).await?;
+
+        Db::migrate_received_notes_pool(&mut connection).await?;
+
+        let pools: Vec<(Vec<u8>, u8)> = sqlx::query("SELECT nf, pool FROM received_notes")
+            .map(|r: SqliteRow| (r.get(0), r.get(1)))
+            .fetch_all(&mut connection)
+            .await?;
+        assert_eq!(
+            pools,
+            vec![
+                (b"sapling-nf".to_vec(), POOL_SAPLING),
+                (b"orchard-nf".to_vec(), POOL_ORCHARD),
+            ]
+        );
+
+        // An Ironwood note at a position already used by another pool is now accepted...
+        insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf").await?;
+        // ...while a genuine duplicate within one pool is still rejected.
+        assert!(
+            insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf-2")
+                .await
+                .is_err()
+        );
+
+        // Re-running the migration is a no-op.
+        Db::migrate_received_notes_pool(&mut connection).await?;
+        let (count,): (u32,) = sqlx::query_as("SELECT COUNT(*) FROM received_notes")
+            .fetch_one(&mut connection)
+            .await?;
+        assert_eq!(count, 3);
+
+        Ok(())
     }
 }

--- a/src/generated/cash.z.wallet.sdk.rpc.rs
+++ b/src/generated/cash.z.wallet.sdk.rpc.rs
@@ -52,6 +52,12 @@ pub struct CompactTx {
     pub outputs: ::prost::alloc::vec::Vec<CompactSaplingOutput>,
     #[prost(message, repeated, tag = "6")]
     pub actions: ::prost::alloc::vec::Vec<CompactOrchardAction>,
+    /// Actions of the Ironwood (NU6.3) bundle. Ironwood reuses Orchard's action encoding and
+    /// keys, but its notes live in a *separate* commitment tree and use the V3 note-plaintext
+    /// lead byte, so they must be trial-decrypted with the Ironwood note-encryption domain and
+    /// positioned against the Ironwood tree. Only populated by versioned-protocol servers.
+    #[prost(message, repeated, tag = "9")]
+    pub ironwood_actions: ::prost::alloc::vec::Vec<CompactOrchardAction>,
 }
 /// CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash
 /// protocol specification.
@@ -103,14 +109,21 @@ pub struct BlockId {
 }
 /// BlockRange specifies a series of blocks from start to end inclusive.
 /// Both BlockIDs must be heights; specification by hash is not yet supported.
+///
+/// `poolTypes` selects which value pools the server should include in the returned
+/// compact blocks. It is part of the *versioned* lightwallet-protocol
+/// (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
+/// advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
+/// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
+/// legacy default (Sapling + Orchard only).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockRange {
     #[prost(message, optional, tag = "1")]
     pub start: ::core::option::Option<BlockId>,
     #[prost(message, optional, tag = "2")]
     pub end: ::core::option::Option<BlockId>,
-    #[prost(uint64, tag = "3")]
-    pub spam_filter_threshold: u64,
+    #[prost(enumeration = "PoolType", repeated, tag = "3")]
+    pub pool_types: ::prost::alloc::vec::Vec<i32>,
 }
 /// A TxFilter contains the information needed to identify a particular
 /// transaction: either a block and an index, or a direct transaction hash.
@@ -195,6 +208,20 @@ pub struct LightdInfo {
     /// example: "/MagicBean:4.1.1/"
     #[prost(string, tag = "14")]
     pub zcashd_subversion: ::prost::alloc::string::String,
+    /// Zcash donation UA address
+    #[prost(string, tag = "15")]
+    pub donation_address: ::prost::alloc::string::String,
+    /// name of next pending network upgrade, empty if none scheduled
+    #[prost(string, tag = "16")]
+    pub upgrade_name: ::prost::alloc::string::String,
+    /// height of next pending upgrade, zero if none is scheduled
+    #[prost(uint64, tag = "17")]
+    pub upgrade_height: u64,
+    /// Version of https://github.com/zcash/lightwallet-protocol served by this server.
+    /// Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
+    /// (and hence Ironwood data in compact blocks).
+    #[prost(string, tag = "18")]
+    pub lightwallet_protocol_version: ::prost::alloc::string::String,
 }
 /// TransparentAddressBlockFilter restricts the results to the given address
 /// or block range.
@@ -266,6 +293,9 @@ pub struct TreeState {
     /// orchard commitment tree state
     #[prost(string, tag = "6")]
     pub orchard_tree: ::prost::alloc::string::String,
+    /// ironwood (NU6.3) commitment tree state
+    #[prost(string, tag = "7")]
+    pub ironwood_tree: ::prost::alloc::string::String,
 }
 /// Results are sorted by height, which makes it easy to issue another
 /// request that picks up from where the previous left off.
@@ -298,6 +328,16 @@ pub struct GetAddressUtxosReply {
 pub struct GetAddressUtxosReplyList {
     #[prost(message, repeated, tag = "1")]
     pub address_utxos: ::prost::alloc::vec::Vec<GetAddressUtxosReply>,
+}
+/// An identifier for a Zcash value pool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PoolType {
+    Invalid = 0,
+    Transparent = 1,
+    Sapling = 2,
+    Orchard = 3,
+    Ironwood = 4,
 }
 #[doc = r" Generated client implementations."]
 pub mod compact_tx_streamer_client {

--- a/src/network.rs
+++ b/src/network.rs
@@ -38,4 +38,5 @@ pub const REGTEST: LocalNetwork = LocalNetwork {
     nu6: Some(BlockHeight::from_u32(1)),
     nu6_1: Some(BlockHeight::from_u32(1)),
     nu6_2: Some(BlockHeight::from_u32(1)),
+    nu6_3: Some(BlockHeight::from_u32(1)),
 };

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,7 +2,7 @@ use crate::account::AccountBalance;
 use crate::db::Db;
 use crate::lwd_rpc::compact_tx_streamer_client::CompactTxStreamerClient;
 use crate::lwd_rpc::*;
-use crate::scan::{get_latest_height, Decoder, Orchard, Sapling, ScanError};
+use crate::scan::{get_latest_height, Decoders, ScanError};
 use crate::transaction::Transfer;
 use crate::{from_tonic, WalletConfig};
 use anyhow::Result;
@@ -266,19 +266,7 @@ pub async fn request_scan(
         .ok_or(anyhow::anyhow!("Block Hash missing from db"))?;
 
     let nfs = db.get_nfs().await?;
-    let mut sap_dec = ufvk.sapling().map(|fvk| {
-        let nk = fvk.fvk().vk.nk;
-        let ivk = fvk.to_ivk(zip32::Scope::External);
-        let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
-        // TODO: Load nfs
-        Decoder::<Sapling>::new(nk, fvk.clone(), pivk, &nfs)
-    });
-    let mut orc_dec = ufvk.orchard().map(|fvk| {
-        let ivk = fvk.to_ivk(zip32::Scope::External);
-        let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-        // TODO: Load nfs
-        Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, &nfs)
-    });
+    let mut decoders = Decoders::new(ufvk, &nfs);
 
     let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
         .await
@@ -296,8 +284,7 @@ pub async fn request_scan(
         start + 1,
         end,
         &prev_hash,
-        &mut sap_dec,
-        &mut orc_dec,
+        &mut decoders,
     )
     .await;
     match res {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use orchard::{
     keys::FullViewingKey,
     note::{ExtractedNoteCommitment, Nullifier},
-    note_encryption::{CompactAction, OrchardDomain},
+    note_encryption::{
+        CompactAction, DomainVersion, IronwoodVersion, NoteEncryptionDomain, OrchardVersion,
+    },
     primitives::redpallas::{Signature, SpendAuth},
     Action, Address,
 };
@@ -17,7 +19,7 @@ use sapling_crypto::{
 use thiserror::Error;
 use tonic::{transport::Channel, Request};
 use zcash_address::unified::{self, Encoding};
-use zcash_keys::encoding::AddressCodec;
+use zcash_keys::{encoding::AddressCodec, keys::UnifiedFullViewingKey};
 use zcash_note_encryption::{
     try_compact_note_decryption, try_note_decryption, EphemeralKeyBytes, ShieldedOutput,
 };
@@ -33,10 +35,19 @@ use zcash_protocol::{
 use crate::{
     lwd_rpc::{
         compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
-        CompactOrchardAction, CompactSaplingOutput, TxFilter,
+        CompactOrchardAction, CompactSaplingOutput, Empty, PoolType, TxFilter,
     },
     network::Network, Client, Hash,
 };
+
+/// Pool codes recorded on a received note (and on the `receivers` row derived from it).
+pub const POOL_SAPLING: u8 = 1;
+pub const POOL_ORCHARD: u8 = 2;
+/// Ironwood (NU6.3). Ironwood notes are received at ordinary Orchard addresses — the pool
+/// distinction lives at the bundle / note-version level, not in the address encoding — but
+/// they live in their own commitment tree, so they need their own pool code to keep note
+/// positions unambiguous.
+pub const POOL_IRONWOOD: u8 = 3;
 
 pub async fn get_latest_height(client: &mut CompactTxStreamerClient<Channel>) -> Result<u32> {
     let latest_block_id = client
@@ -47,15 +58,94 @@ pub async fn get_latest_height(client: &mut CompactTxStreamerClient<Channel>) ->
     Ok(latest_height as u32)
 }
 
+/// The `BlockRange.poolTypes` selector to use against this server.
+///
+/// Ironwood actions only ride in compact blocks when they are explicitly requested, and the
+/// field is part of the *versioned* lightwallet-protocol: a client must confirm the server
+/// advertises `lightwalletProtocolVersion` before setting it, because a legacy server may
+/// reject it or misinterpret tag 3. Against a legacy server we send an empty selector and get
+/// the legacy default (Sapling + Orchard) — correct behaviour pre-NU6.3, and the operator
+/// needs an upgraded lightwalletd to see Ironwood receives once NU6.3 activates.
+pub async fn pool_types(client: &mut Client) -> Result<Vec<i32>> {
+    let info = client
+        .get_lightd_info(Request::new(Empty {}))
+        .await?
+        .into_inner();
+    if info.lightwallet_protocol_version.is_empty() {
+        log::warn!(
+            "lightwalletd {} does not advertise a lightwallet-protocol version; \
+             Ironwood (NU6.3) notes cannot be detected. Upgrade the server to scan NU6.3 blocks.",
+            info.version
+        );
+        Ok(vec![])
+    } else {
+        Ok(vec![
+            PoolType::Sapling as i32,
+            PoolType::Orchard as i32,
+            PoolType::Ironwood as i32,
+        ])
+    }
+}
+
+/// The per-pool trial-decryption state carried across a scan.
+pub struct Decoders {
+    pub sapling: Option<Decoder<Sapling>>,
+    pub orchard: Option<Decoder<Orchard>>,
+    pub ironwood: Option<Decoder<Ironwood>>,
+}
+
+impl Decoders {
+    /// Build the per-pool decoders for `ufvk`, seeded with the wallet's known nullifiers.
+    pub fn new(ufvk: &UnifiedFullViewingKey, nfs: &HashMap<Hash, u64>) -> Self {
+        let sapling = ufvk.sapling().map(|fvk| {
+            let nk = fvk.fvk().vk.nk;
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, nfs)
+        });
+        let orchard = ufvk.orchard().map(|fvk| {
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, nfs)
+        });
+        // Ironwood is received at the account's Orchard receivers and derives from the same
+        // Orchard key material — only the note plaintext version and the commitment tree
+        // differ — so its decoder is built from the very same FVK.
+        let ironwood = ufvk.orchard().map(|fvk| {
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Ironwood>::new(fvk.clone(), ivk, pivk, nfs)
+        });
+        Decoders {
+            sapling,
+            orchard,
+            ironwood,
+        }
+    }
+
+    /// Look a nullifier up against both Orchard-family decoders.
+    ///
+    /// Orchard and Ironwood derive nullifiers from the same account key, and a note is nullified
+    /// in whichever bundle owns its pool — an Orchard V2 note in the Orchard bundle, an Ironwood
+    /// V3 note in the Ironwood bundle — so a spend must be matched against both sets regardless
+    /// of which action list it was seen in.
+    fn orchard_family_nf(&self, nf: &Hash) -> Option<u64> {
+        self.orchard
+            .as_ref()
+            .and_then(|d| d.nfs.get(nf).copied())
+            .or_else(|| self.ironwood.as_ref().and_then(|d| d.nfs.get(nf).copied()))
+    }
+}
+
 pub async fn scan(
     network: &Network,
     client: &mut Client,
     start: u32,
     end: u32,
     prev_hash: &Hash,
-    sap_dec: &mut Option<Decoder<Sapling>>,
-    orc_dec: &mut Option<Decoder<Orchard>>,
+    decoders: &mut Decoders,
 ) -> Result<Vec<ScanEvent>, ScanError> {
+    let pool_types = pool_types(client).await.map_err(ScanError::Other)?;
     let tree_state = client
         .get_tree_state(Request::new(BlockId {
             height: start as u64,
@@ -75,7 +165,7 @@ pub async fn scan(
                 height: end as u64,
                 hash: vec![],
             }),
-            spam_filter_threshold: 0,
+            pool_types,
         }))
         .await
         .map_err(|e| ScanError::Other(anyhow::Error::new(e)))?
@@ -83,6 +173,9 @@ pub async fn scan(
     let mut prev_hash = *prev_hash;
     let mut sap_position = get_tree_size(&tree_state.sapling_tree).unwrap();
     let mut orc_position = get_tree_size(&tree_state.orchard_tree).unwrap();
+    // Ironwood has its own commitment tree, so its note positions are tracked separately from
+    // Orchard's. Empty (hence 0) before NU6.3 activates, and on servers that don't serve it.
+    let mut irw_position = get_tree_size(&tree_state.ironwood_tree).unwrap();
 
     let mut events = vec![];
     let mut new_txids = vec![];
@@ -97,7 +190,7 @@ pub async fn scan(
 
         for vtx in block.vtx.iter() {
             let mut found = false;
-            if let Some(sap_dec) = sap_dec {
+            if let Some(sap_dec) = decoders.sapling.as_mut() {
                 for i in vtx.spends.iter() {
                     let nf: &Hash = i.nf.as_slice().try_into().unwrap();
                     if let Some(value) = sap_dec.nfs.get(nf) {
@@ -125,17 +218,22 @@ pub async fn scan(
                 }
             }
 
-            if let Some(orc_dec) = orc_dec {
-                for (vout, a) in vtx.actions.iter().enumerate() {
-                    let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
-                    if let Some(value) = orc_dec.nfs.get(nf) {
-                        events.push(ScanEvent::Spent(SpentNote {
-                            height,
-                            nf: *nf,
-                            txid: vtx.hash.clone().try_into().unwrap(),
-                            value: *value,
-                        }));
-                    }
+            // Orchard and Ironwood actions are structurally identical and share the account's
+            // Orchard keys; they differ in the note-plaintext version (so each needs its own
+            // trial-decryption domain) and in which commitment tree positions them. A note is
+            // nullified in whichever bundle owns its pool, so spends are looked up against both
+            // decoders' nullifier sets.
+            for (vout, a) in vtx.actions.iter().enumerate() {
+                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
+                if let Some(value) = decoders.orchard_family_nf(nf) {
+                    events.push(ScanEvent::Spent(SpentNote {
+                        height,
+                        nf: *nf,
+                        txid: vtx.hash.clone().try_into().unwrap(),
+                        value,
+                    }));
+                }
+                if let Some(orc_dec) = decoders.orchard.as_mut() {
                     if let Some(n) = orc_dec.try_compact_note_decryption(
                         network,
                         height,
@@ -150,6 +248,31 @@ pub async fn scan(
                 }
             }
 
+            for (vout, a) in vtx.ironwood_actions.iter().enumerate() {
+                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
+                if let Some(value) = decoders.orchard_family_nf(nf) {
+                    events.push(ScanEvent::Spent(SpentNote {
+                        height,
+                        nf: *nf,
+                        txid: vtx.hash.clone().try_into().unwrap(),
+                        value,
+                    }));
+                }
+                if let Some(irw_dec) = decoders.ironwood.as_mut() {
+                    if let Some(n) = irw_dec.try_compact_note_decryption(
+                        network,
+                        height,
+                        &vtx.hash,
+                        irw_position + vout as u32,
+                        a,
+                    )? {
+                        irw_dec.add_nf(n.nf, n.value);
+                        events.push(ScanEvent::Received(n));
+                        found = true;
+                    }
+                }
+            }
+
             if found {
                 let txid: Hash = vtx.hash.clone().try_into().unwrap();
                 new_txids.push(WalletTx {
@@ -157,16 +280,18 @@ pub async fn scan(
                     txid,
                     sap_position,
                     orc_position,
+                    irw_position,
                 });
             }
 
             sap_position += vtx.outputs.len() as u32;
             orc_position += vtx.actions.len() as u32;
+            irw_position += vtx.ironwood_actions.len() as u32;
         }
     }
 
     for wtx in new_txids.iter() {
-        let memos = scan_tx(network, client, wtx, sap_dec, orc_dec).await?;
+        let memos = scan_tx(network, client, wtx, decoders).await?;
         for m in memos {
             events.push(ScanEvent::Memo(m));
         }
@@ -180,8 +305,7 @@ pub async fn scan_tx(
     network: &Network,
     client: &mut Client,
     wtx: &WalletTx,
-    sap_dec: &Option<Decoder<Sapling>>,
-    orc_dec: &Option<Decoder<Orchard>>,
+    decoders: &Decoders,
 ) -> Result<Vec<MemoNote>> {
     let mut notes = vec![];
     let raw_tx = client
@@ -195,7 +319,7 @@ pub async fn scan_tx(
     let tx = Transaction::read(&*raw_tx.data, branch_id)?;
     let tx = tx.into_data();
 
-    if let Some(sap_dec) = sap_dec {
+    if let Some(sap_dec) = decoders.sapling.as_ref() {
         if let Some(sapling_bundle) = tx.sapling_bundle() {
             for (vout, o) in sapling_bundle.shielded_outputs().iter().enumerate() {
                 if let Some(note) =
@@ -206,11 +330,24 @@ pub async fn scan_tx(
             }
         }
     }
-    if let Some(orc_dec) = orc_dec {
+    if let Some(orc_dec) = decoders.orchard.as_ref() {
         if let Some(orchard_bundle) = tx.orchard_bundle() {
             for (vout, a) in orchard_bundle.actions().iter().enumerate() {
                 if let Some(note) =
                     orc_dec.try_note_decryption(vout as u32 + wtx.orc_position, a)?
+                {
+                    notes.push(note);
+                }
+            }
+        }
+    }
+    // A V6 transaction carries the Orchard and Ironwood bundles side by side; memos for
+    // Ironwood notes are in the latter, decrypted with the Ironwood domain.
+    if let Some(irw_dec) = decoders.ironwood.as_ref() {
+        if let Some(ironwood_bundle) = tx.ironwood_bundle() {
+            for (vout, a) in ironwood_bundle.actions().iter().enumerate() {
+                if let Some(note) =
+                    irw_dec.try_note_decryption(vout as u32 + wtx.irw_position, a)?
                 {
                     notes.push(note);
                 }
@@ -347,7 +484,7 @@ impl Decode<Sapling> for Decoder<Sapling> {
 
             let note = ReceivedNote {
                 txid: txid.try_into().unwrap(),
-                pool: 1,
+                pool: POOL_SAPLING,
                 position,
                 height,
                 address,
@@ -400,6 +537,122 @@ impl Pool for Orchard {
     type Output = Action<Signature<SpendAuth>>;
 }
 
+/// Ironwood, the shielded pool introduced by NU6.3.
+///
+/// Ironwood reuses Orchard's keys, addresses and action encoding wholesale, so a wallet needs no
+/// new key material and no new address type to receive into it: an Ironwood note is simply
+/// received at an ordinary Orchard receiver. What differs is (a) the note plaintext version —
+/// lead byte `0x03` instead of Orchard's `0x02`, so trial decryption needs the Ironwood domain —
+/// and (b) the commitment tree, which is separate from Orchard's and therefore has its own
+/// note positions. Once NU6.3 activates, payments to an Orchard receiver are *routed to this
+/// pool*, so a wallet that only scans `CompactTx.actions` stops seeing its own incoming
+/// payments.
+pub struct Ironwood;
+
+impl Pool for Ironwood {
+    type Address = Address;
+    type NullifierKey = FullViewingKey;
+    type DiversifierKey = orchard::keys::IncomingViewingKey;
+    type PreparedIncomingViewingKey = orchard::keys::PreparedIncomingViewingKey;
+    type CompactOutput = CompactOrchardAction;
+    type Output = Action<Signature<SpendAuth>>;
+}
+
+/// The account keys shared by the Orchard-family pools, plus the pool code to tag notes with.
+struct OrchardFamilyKeys<'a> {
+    nk: &'a FullViewingKey,
+    dk: &'a orchard::keys::IncomingViewingKey,
+    pivk: &'a orchard::keys::PreparedIncomingViewingKey,
+    pool: u8,
+}
+
+/// Trial-decrypt a compact Orchard-family action under the note-plaintext version `V`
+/// (`OrchardVersion` for the Orchard bundle, `IronwoodVersion` for the Ironwood bundle).
+fn orchard_family_compact_decryption<V: DomainVersion>(
+    keys: &OrchardFamilyKeys<'_>,
+    network: &Network,
+    height: u32,
+    txid: &[u8],
+    position: u32,
+    action: &CompactOrchardAction,
+) -> Result<Option<ReceivedNote>> {
+    let epk: &[u8; 32] = action.ephemeral_key.as_slice().try_into().unwrap();
+    let ca = CompactAction::from_parts(
+        Nullifier::from_bytes(action.nullifier.as_slice().try_into().unwrap()).unwrap(),
+        ExtractedNoteCommitment::from_bytes(action.cmx.as_slice().try_into().unwrap()).unwrap(),
+        EphemeralKeyBytes(*epk),
+        action.ciphertext.as_slice().try_into().unwrap(),
+    );
+    let domain = NoteEncryptionDomain::<V>::for_compact_action(&ca);
+    if let Some((note, address)) = try_compact_note_decryption(&domain, keys.pivk, &ca) {
+        let ua = unified::Receiver::Orchard(address.to_raw_address_bytes());
+        let ua = unified::Address::try_from_items(vec![ua])?;
+        let ua = ua.encode(&network.network_type());
+        let diversifier = *address.diversifier().as_array();
+        let value = note.value().inner();
+        let rcm = *note.rseed().as_bytes();
+        let nf = note.nullifier(keys.nk);
+        let rho = note.rho().to_bytes();
+        let di = orchard_family_diversifier(keys.dk, &address)?;
+
+        let note = ReceivedNote {
+            txid: txid.try_into().unwrap(),
+            pool: keys.pool,
+            position,
+            height,
+            address: ua,
+            diversifier,
+            diversifier_index: di,
+            value,
+            rcm,
+            nf: nf.to_bytes(),
+            rho: Some(rho),
+        };
+        return Ok(Some(note));
+    }
+    Ok(None)
+}
+
+/// Full trial decryption of an Orchard-family action, to recover the note's memo.
+fn orchard_family_note_decryption<V: DomainVersion>(
+    keys: &OrchardFamilyKeys<'_>,
+    action: &Action<Signature<SpendAuth>>,
+) -> Result<Option<MemoNote>> {
+    let domain = NoteEncryptionDomain::<V>::for_action(action);
+    if let Some((note, _address, memo_bytes)) = try_note_decryption(&domain, keys.pivk, action) {
+        let nf = note.nullifier(keys.nk);
+        let memo_note = MemoNote {
+            nf: nf.to_bytes(),
+            memo: memo_text(&memo_bytes)?,
+        };
+        return Ok(Some(memo_note));
+    }
+
+    Ok(None)
+}
+
+fn orchard_family_diversifier(
+    dk: &orchard::keys::IncomingViewingKey,
+    address: &Address,
+) -> Result<Option<u64>> {
+    if let Some(di) = dk.diversifier_index(address) {
+        let di: u64 = di.try_into()?;
+        return Ok(Some(di));
+    }
+    Ok(None)
+}
+
+impl Decoder<Orchard> {
+    fn keys(&self) -> OrchardFamilyKeys<'_> {
+        OrchardFamilyKeys {
+            nk: &self.nk,
+            dk: &self.dk,
+            pivk: &self.pivk,
+            pool: POOL_ORCHARD,
+        }
+    }
+}
+
 impl Decode<Orchard> for Decoder<Orchard> {
     fn try_compact_note_decryption(
         &self,
@@ -409,41 +662,14 @@ impl Decode<Orchard> for Decoder<Orchard> {
         position: u32,
         action: &CompactOrchardAction,
     ) -> Result<Option<ReceivedNote>> {
-        let epk: &[u8; 32] = action.ephemeral_key.as_slice().try_into().unwrap();
-        let ca = CompactAction::from_parts(
-            Nullifier::from_bytes(action.nullifier.as_slice().try_into().unwrap()).unwrap(),
-            ExtractedNoteCommitment::from_bytes(action.cmx.as_slice().try_into().unwrap()).unwrap(),
-            EphemeralKeyBytes(*epk),
-            action.ciphertext.as_slice().try_into().unwrap(),
-        );
-        let domain = OrchardDomain::for_compact_action(&ca);
-        if let Some((note, address)) = try_compact_note_decryption(&domain, &self.pivk, &ca) {
-            let ua = unified::Receiver::Orchard(address.to_raw_address_bytes());
-            let ua = unified::Address::try_from_items(vec![ua])?;
-            let ua = ua.encode(&network.network_type());
-            let diversifier = *address.diversifier().as_array();
-            let value = note.value().inner();
-            let rcm = *note.rseed().as_bytes();
-            let nf = note.nullifier(&self.nk);
-            let rho = note.rho().to_bytes();
-            let di = self.decrypt_diversifier(&address)?;
-
-            let note = ReceivedNote {
-                txid: txid.try_into().unwrap(),
-                pool: 2,
-                position,
-                height,
-                address: ua,
-                diversifier,
-                diversifier_index: di,
-                value,
-                rcm,
-                nf: nf.to_bytes(),
-                rho: Some(rho),
-            };
-            return Ok(Some(note));
-        }
-        Ok(None)
+        orchard_family_compact_decryption::<OrchardVersion>(
+            &self.keys(),
+            network,
+            height,
+            txid,
+            position,
+            action,
+        )
     }
 
     fn try_note_decryption(
@@ -451,26 +677,54 @@ impl Decode<Orchard> for Decoder<Orchard> {
         _position: u32,
         action: &Action<Signature<SpendAuth>>,
     ) -> Result<Option<MemoNote>> {
-        let domain = OrchardDomain::for_action(action);
-        if let Some((note, _address, memo_bytes)) = try_note_decryption(&domain, &self.pivk, action)
-        {
-            let nf = note.nullifier(&self.nk);
-            let memo_note = MemoNote {
-                nf: nf.to_bytes(),
-                memo: memo_text(&memo_bytes)?,
-            };
-            return Ok(Some(memo_note));
-        }
-
-        Ok(None)
+        orchard_family_note_decryption::<OrchardVersion>(&self.keys(), action)
     }
 
     fn decrypt_diversifier(&self, address: &Address) -> Result<Option<u64>> {
-        if let Some(di) = self.dk.diversifier_index(address) {
-            let di: u64 = di.try_into()?;
-            return Ok(Some(di));
+        orchard_family_diversifier(&self.dk, address)
+    }
+}
+
+impl Decoder<Ironwood> {
+    fn keys(&self) -> OrchardFamilyKeys<'_> {
+        OrchardFamilyKeys {
+            nk: &self.nk,
+            dk: &self.dk,
+            pivk: &self.pivk,
+            pool: POOL_IRONWOOD,
         }
-        Ok(None)
+    }
+}
+
+impl Decode<Ironwood> for Decoder<Ironwood> {
+    fn try_compact_note_decryption(
+        &self,
+        network: &Network,
+        height: u32,
+        txid: &[u8],
+        position: u32,
+        action: &CompactOrchardAction,
+    ) -> Result<Option<ReceivedNote>> {
+        orchard_family_compact_decryption::<IronwoodVersion>(
+            &self.keys(),
+            network,
+            height,
+            txid,
+            position,
+            action,
+        )
+    }
+
+    fn try_note_decryption(
+        &self,
+        _position: u32,
+        action: &Action<Signature<SpendAuth>>,
+    ) -> Result<Option<MemoNote>> {
+        orchard_family_note_decryption::<IronwoodVersion>(&self.keys(), action)
+    }
+
+    fn decrypt_diversifier(&self, address: &Address) -> Result<Option<u64>> {
+        orchard_family_diversifier(&self.dk, address)
     }
 }
 
@@ -519,6 +773,7 @@ pub struct WalletTx {
     pub txid: Hash,
     pub sap_position: u32,
     pub orc_position: u32,
+    pub irw_position: u32,
 }
 
 pub fn memo_text(memo_bytes: &[u8]) -> Result<String> {
@@ -557,17 +812,7 @@ mod tests {
             hex::decode("5f03d35ae940bb840564c3b7af7ab72255096d3eca15c910c0e40d0000000000")
                 .unwrap();
         let ufvk = zcash_keys::keys::UnifiedFullViewingKey::decode(&Network::Main, FVK).unwrap();
-        let mut sap_dec = ufvk.sapling().map(|fvk| {
-            let nk = fvk.fvk().vk.nk;
-            let ivk = fvk.to_ivk(zip32::Scope::External);
-            let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, &HashMap::new())
-        });
-        let mut orc_dec = ufvk.orchard().map(|fvk| {
-            let ivk = fvk.to_ivk(zip32::Scope::External);
-            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, &HashMap::new())
-        });
+        let mut decoders = Decoders::new(&ufvk, &HashMap::new());
 
         let events = scan(
             &Network::Main,
@@ -575,14 +820,19 @@ mod tests {
             2_890_000,
             2_900_000,
             &prev_hash.try_into().unwrap(),
-            &mut sap_dec,
-            &mut orc_dec,
+            &mut decoders,
         )
         .await?;
 
         println!("{events:?}");
 
-        let db = Db::new(Network::Main, "zec-wallet-test.db", &ufvk, "").await?;
+        // Scratch database, recreated on each run: `store_events` is not idempotent (note
+        // nullifiers are UNIQUE), and `Db::new` alone does not build the schema.
+        let db_path = std::env::temp_dir().join("zec-wallet-test.db");
+        let _ = std::fs::remove_file(&db_path);
+        let db = Db::new(Network::Main, &db_path.to_string_lossy(), &ufvk, "").await?;
+        db.create().await?;
+        db.new_account("").await?;
         db.store_events(&events).await?;
 
         Ok(())


### PR DESCRIPTION
This is an AI-written pull request that I have not yet tested with BTCPayServer. Posting this in case it's of interest to anyone else looking for NU6.3 support in zcash-walletd.

---

NU6.3 adds the Ironwood shielded pool. Ironwood reuses Orchard's keys, addresses and action encoding, so no new address type is needed — an Ironwood note is received at an ordinary Orchard receiver of a UA. What differs is that Ironwood notes use note-plaintext version V3 (lead byte 0x03) and live in their own commitment tree, and that once NU6.3 activates payments to an Orchard receiver are routed to the Ironwood pool. A wallet that scans only the Orchard bundle therefore stops seeing its own incoming payments after activation.

- Bump the librustzcash stack to the ironwood line from crates.io (orchard 0.15, zcash_primitives/zcash_proofs 0.30, zcash_protocol 0.10, zcash_keys 0.16, zcash_address 0.13, zcash_client_backend 0.24.0-rc.4). Ironwood is not a cargo feature; activation is consensus-height driven, so a plain build is NU6.3-ready on every network. Add nu6_3 to the regtest LocalNetwork.
- Update the protos to the versioned lightwallet-protocol: CompactTx.ironwoodActions, TreeState.ironwoodTree, BlockRange.poolTypes (replacing spamFilterThreshold on tag 3), the PoolType enum, and the LightdInfo fields through lightwalletProtocolVersion.
- Scan the Ironwood bundle: an Ironwood decoder built from the same Orchard FVK but the Ironwood note-encryption domain, positions tracked against the Ironwood commitment tree, and memos recovered from the V6 transaction's ironwood bundle. Spends are matched against both Orchard-family nullifier sets, since a note is nullified in whichever bundle owns its pool.
- Request poolTypes only from a server advertising LightdInfo.lightwalletProtocolVersion, as the protocol requires: a legacy server may reject or misinterpret tag 3. Against one we fall back to the Sapling+Orchard default and log a warning — the public fleet is still v0.5.1 with no protocol version, so operators must upgrade lightwalletd before the activation height to see Ironwood receives.
- Record a note's pool in received_notes and key the uniqueness constraint on (pool, position). Note positions are only unique within a pool's own tree and Ironwood's restarts at zero, so the old UNIQUE (position) would reject the first Ironwood receives and fail the whole scan batch. Existing databases migrate automatically — the pool of an existing row is recoverable from rho without a rescan — so no database reset is needed.

Also fixes the scan test, which never created its schema and so failed on any clean checkout.
