### PR TITLE
Harden Ironwood persistence and wallet progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
+ "nanorand",
  "spin 0.9.8",
 ]
 
@@ -1048,8 +1049,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1475,7 +1478,7 @@ dependencies = [
  "hyper 1.10.1",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1890,6 +1893,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3233,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
+checksum = "8147447aed7be4736e271825b8c3a4432efb7182e71363169b572371ddef452e"
 dependencies = [
  "bitflags 2.10.0",
  "either",
@@ -4892,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -4906,17 +4918,17 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.23.0"
+version = "0.24.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "base64 0.22.1",
  "bech32",
  "bip32",
  "bls12_381",
  "bs58",
- "crossbeam-channel",
  "document-features",
+ "flume",
  "getset",
  "group",
  "hex",
@@ -4936,7 +4948,6 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "time-core",
  "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
@@ -4967,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "bip32",
@@ -5009,9 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5040,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5062,9 +5073,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -5101,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -5232,9 +5243,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.8.0"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64 0.22.1",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bls12_381 = "0.8"
 jubjub = "0.10"
 ff = "0.13"
 group = "0.13"
-orchard = "0.14.0"
+orchard = "0.15"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
@@ -49,16 +49,21 @@ sapling-crypto = "0.7"
 zcash_note_encryption = "0.4.1"
 zip32 = "0.2"
 
-zcash_client_backend = { version = "0.23", features = [
+# NU6.3 (Ironwood) support: the librustzcash "ironwood" line, consumed from crates.io. The
+# leaf crates are finals; the wallet crates are still release candidates — move these reqs to
+# the finals once they publish. Ironwood is *not* a cargo feature: the published line exposes
+# the ironwood APIs unconditionally, and activation is purely consensus-height driven
+# (`NetworkUpgrade::Nu6_3`), so a plain `cargo build` is NU6.3-ready on every network.
+zcash_client_backend = { version = "0.24.0-rc.4", features = [
     "lightwalletd-tonic-tls-webpki-roots",
     "orchard",
     "transparent-inputs",
 ] }
-zcash_keys = { version = "0.14", features = ["orchard", "sapling"] }
-zcash_protocol = { version = "0.9", features = ["local-consensus"] }
-zcash_address = { version = "0.12" }
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
+zcash_keys = { version = "0.16", features = ["orchard", "sapling"] }
+zcash_protocol = { version = "0.10", features = ["local-consensus"] }
+zcash_address = { version = "0.13" }
+zcash_primitives = "0.30"
+zcash_proofs = "0.30"
 
 [build-dependencies]
 tonic-build = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`zcash-walletd` is a shielded only (sapling, orchard, UA) REST wallet
+`zcash-walletd` is a shielded only (sapling, orchard, ironwood, UA) REST wallet
 for zcash.
 
 Primary intended to work with the BTCPayServer payment gateway,
@@ -58,3 +58,29 @@ The latest image is available on DockerHub under `hhanh00/zcash-walletd:latest`
 ## Orchard
 Support for Orchard and UA was added in 1.1.2. You MUST delete the database file
 because the previous schema is not compatible.
+
+## NU6.3 (Ironwood)
+
+NU6.3 introduces the **Ironwood** shielded pool. Ironwood reuses Orchard's keys, addresses and
+action encoding, so **no new address type and no re-issuing of addresses is needed**: an
+Ironwood note is received at an ordinary Orchard receiver of a UA. What differs is that
+Ironwood notes use their own note-plaintext version and live in their own commitment tree, and
+that **once NU6.3 activates, payments to an Orchard receiver are routed to the Ironwood pool**.
+A wallet that scans only the Orchard bundle therefore stops seeing its own incoming payments
+after activation.
+
+`zcash-walletd` scans both pools. Two things are required of the deployment:
+
+- **Upgrade `lightwalletd`.** Ironwood data only rides in compact blocks when the client asks
+  for it via `BlockRange.poolTypes`, which is part of the versioned
+  [lightwallet-protocol](https://github.com/zcash/lightwallet-protocol). `zcash-walletd`
+  requests it only from a server that advertises `LightdInfo.lightwalletProtocolVersion`, since
+  a legacy server may reject or misinterpret the field. Against a legacy (<= v0.4.x) server it
+  falls back to the Sapling + Orchard default and logs a warning — correct before activation,
+  but Ironwood receives will be **invisible** after it. Upgrade the server before the NU6.3
+  activation height.
+- **No database reset is needed.** The `received_notes` table gains a `pool` column on first
+  start (note positions are only unique within a pool's own commitment tree, and Ironwood's
+  restarts at zero); the migration runs automatically and preserves existing rows.
+
+Activation is consensus-height driven — there is no build flag and no configuration switch.

--- a/proto/compact_formats.proto
+++ b/proto/compact_formats.proto
@@ -40,6 +40,11 @@ message CompactTx {
     repeated CompactSaplingSpend spends = 4;   // inputs
     repeated CompactSaplingOutput outputs = 5; // outputs
     repeated CompactOrchardAction actions = 6;
+    // Actions of the Ironwood (NU6.3) bundle. Ironwood reuses Orchard's action encoding and
+    // keys, but its notes live in a *separate* commitment tree and use the V3 note-plaintext
+    // lead byte, so they must be trial-decrypted with the Ironwood note-encryption domain and
+    // positioned against the Ironwood tree. Only populated by versioned-protocol servers.
+    repeated CompactOrchardAction ironwoodActions = 9;
 }
 
 // CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash

--- a/proto/compact_formats.proto
+++ b/proto/compact_formats.proto
@@ -9,6 +9,13 @@ option swift_prefix = "";
 // Remember that proto3 fields are all optional. A field that is not present will be set to its zero value.
 // bytes fields of hashes are in canonical little-endian format.
 
+// Information about the state of the chain as of a given block.
+message ChainMetadata {
+    uint32 saplingCommitmentTreeSize = 1;
+    uint32 orchardCommitmentTreeSize = 2;
+    uint32 ironwoodCommitmentTreeSize = 3;
+}
+
 // CompactBlock is a packaging of ONLY the data from a block that's needed to:
 //   1. Detect a payment to your shielded Sapling address
 //   2. Detect a spend of your shielded Sapling notes
@@ -21,6 +28,7 @@ message CompactBlock {
     uint32 time = 5;            // Unix epoch time when the block was mined
     bytes header = 6;           // (hash, prevHash, and time) OR (full header)
     repeated CompactTx vtx = 7; // zero or more compact transactions from this block
+    ChainMetadata chainMetadata = 8;
 }
 
 // CompactTx contains the minimum information for a wallet to know if this transaction

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -15,12 +15,28 @@ message BlockID {
      bytes hash = 2;
 }
 
+// An identifier for a Zcash value pool.
+enum PoolType {
+    POOL_TYPE_INVALID = 0;
+    TRANSPARENT = 1;
+    SAPLING = 2;
+    ORCHARD = 3;
+    IRONWOOD = 4;
+}
+
 // BlockRange specifies a series of blocks from start to end inclusive.
 // Both BlockIDs must be heights; specification by hash is not yet supported.
+//
+// `poolTypes` selects which value pools the server should include in the returned
+// compact blocks. It is part of the *versioned* lightwallet-protocol
+// (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
+// advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
+// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
+// legacy default (Sapling + Orchard only).
 message BlockRange {
     BlockID start = 1;
     BlockID end = 2;
-    uint64 spamFilterThreshold = 3;
+    repeated PoolType poolTypes = 3;
 }
 
 // A TxFilter contains the information needed to identify a particular
@@ -71,6 +87,13 @@ message LightdInfo {
     uint64 estimatedHeight = 12;        // less than tip height if zcashd is syncing
     string zcashdBuild = 13;            // example: "v4.1.1-877212414"
     string zcashdSubversion = 14;       // example: "/MagicBean:4.1.1/"
+    string donationAddress = 15;        // Zcash donation UA address
+    string upgradeName = 16;            // name of next pending network upgrade, empty if none scheduled
+    uint64 upgradeHeight = 17;          // height of next pending upgrade, zero if none is scheduled
+    // Version of https://github.com/zcash/lightwallet-protocol served by this server.
+    // Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
+    // (and hence Ironwood data in compact blocks).
+    string lightwalletProtocolVersion = 18;
 }
 
 // TransparentAddressBlockFilter restricts the results to the given address
@@ -117,6 +140,7 @@ message TreeState {
     uint32 time = 4;        // Unix epoch time when the block was mined
     string saplingTree = 5; // sapling commitment tree state
     string orchardTree = 6; // orchard commitment tree state
+    string ironwoodTree = 7; // ironwood (NU6.3) commitment tree state
 }
 
 // Results are sorted by height, which makes it easy to issue another

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -31,8 +31,8 @@ enum PoolType {
 // compact blocks. It is part of the *versioned* lightwallet-protocol
 // (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
 // advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
-// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
-// legacy default (Sapling + Orchard only).
+// a legacy server may reject it or silently misinterpret tag 3. Leave it empty to request
+// the default shielded pools (Sapling, Orchard, and Ironwood).
 message BlockRange {
     BlockID start = 1;
     BlockID end = 2;
@@ -91,8 +91,7 @@ message LightdInfo {
     string upgradeName = 16;            // name of next pending network upgrade, empty if none scheduled
     uint64 upgradeHeight = 17;          // height of next pending upgrade, zero if none is scheduled
     // Version of https://github.com/zcash/lightwallet-protocol served by this server.
-    // Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
-    // (and hence Ironwood data in compact blocks).
+    // Empty on legacy servers and some v0.5 implementations.
     string lightwalletProtocolVersion = 18;
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use crate::account::{Account, AccountBalance, SubAccount};
 use crate::lwd_rpc::BlockId;
 use crate::network::Network;
-use crate::scan::ScanEvent;
+use crate::scan::{ScanEvent, POOL_ORCHARD, POOL_SAPLING};
 use crate::transaction::{SubAddress, Transfer};
 use crate::{notify_tx, Client, Hash};
 use anyhow::Result;
@@ -14,6 +14,26 @@ use zcash_keys::address::UnifiedAddress;
 use zcash_keys::encoding::AddressCodec;
 use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+/// Schema of `received_notes`. Kept in one place because the pool migration rebuilds the table
+/// from it (SQLite cannot alter a table constraint in place).
+const RECEIVED_NOTES_DDL: &str = "CREATE TABLE IF NOT EXISTS received_notes (
+    id_note INTEGER PRIMARY KEY,
+    address TEXT NOT NULL,
+    account INTEGER,
+    sub_account INTEGER,
+    id_tx INTEGER NOT NULL,
+    pool INTEGER NOT NULL,
+    position INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    diversifier BLOB NOT NULL,
+    value INTEGER NOT NULL,
+    rcm BLOB NOT NULL,
+    nf BLOB NOT NULL UNIQUE,
+    rho BLOB,
+    memo TEXT,
+    spent INTEGER,
+    CONSTRAINT tx_output UNIQUE (pool, position))";
 
 pub struct Db {
     network: Network,
@@ -41,6 +61,57 @@ impl Db {
             notify_tx_url: notify_tx_url.to_string(),
             address_creation_lock: Mutex::new(()),
         })
+    }
+
+    /// Migrate a pre-NU6.3 `received_notes` table to the pool-aware schema.
+    ///
+    /// Note positions are only unique *within* a pool's commitment tree, and Ironwood's tree
+    /// starts from zero when NU6.3 activates — so its early positions collide head-on with the
+    /// low Sapling/Orchard positions a wallet may already hold, and the old
+    /// `UNIQUE (position)` constraint would reject the insert and wedge the scan. Record the
+    /// note's pool and key the constraint on `(pool, position)` instead.
+    ///
+    /// SQLite can't alter a table constraint in place, so rebuild the table. The pool of an
+    /// existing row is recoverable without rescanning: `rho` is only ever set for
+    /// Orchard-family notes, so a NULL `rho` means Sapling. No pre-migration row can be
+    /// Ironwood — the pool did not exist.
+    async fn migrate_received_notes_pool(connection: &mut SqliteConnection) -> Result<()> {
+        if sqlx::query("SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'pool'")
+            .fetch_optional(&mut *connection)
+            .await?
+            .is_some()
+        {
+            return Ok(());
+        }
+        log::info!("Migrating received_notes to the pool-aware (NU6.3) schema");
+
+        let mut db_transaction = connection.begin().await?;
+        let db_tx = db_transaction.acquire().await?;
+        sqlx::query(&RECEIVED_NOTES_DDL.replace("received_notes", "received_notes_new"))
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query(
+            "INSERT INTO received_notes_new
+            (id_note, address, account, sub_account, id_tx, pool, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            SELECT id_note, address, account, sub_account, id_tx,
+            CASE WHEN rho IS NULL THEN ?1 ELSE ?2 END,
+            position, height, diversifier, value, rcm, nf, rho, memo, spent
+            FROM received_notes",
+        )
+        .bind(POOL_SAPLING)
+        .bind(POOL_ORCHARD)
+        .execute(&mut *db_tx)
+        .await?;
+        sqlx::query("DROP TABLE received_notes")
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query("ALTER TABLE received_notes_new RENAME TO received_notes")
+            .execute(&mut *db_tx)
+            .await?;
+        db_transaction.commit().await?;
+
+        Ok(())
     }
 
     async fn cleanup_stale_data(connection: &mut SqliteConnection) -> Result<()> {
@@ -433,26 +504,9 @@ impl Db {
         .execute(&mut *connection)
         .await?;
 
-        sqlx::query(
-            "CREATE TABLE IF NOT EXISTS received_notes (
-            id_note INTEGER PRIMARY KEY,
-            address TEXT NOT NULL,
-            account INTEGER,
-            sub_account INTEGER,
-            id_tx INTEGER NOT NULL,
-            position INTEGER NOT NULL,
-            height INTEGER NOT NULL,
-            diversifier BLOB NOT NULL,
-            value INTEGER NOT NULL,
-            rcm BLOB NOT NULL,
-            nf BLOB NOT NULL UNIQUE,
-            rho BLOB,
-            memo TEXT,
-            spent INTEGER,
-            CONSTRAINT tx_output UNIQUE (position))",
-        )
-        .execute(&mut *connection)
-        .await?;
+        sqlx::query(RECEIVED_NOTES_DDL)
+            .execute(&mut *connection)
+            .await?;
 
         Self::cleanup_stale_data(&mut connection).await?;
 
@@ -463,6 +517,8 @@ impl Db {
         {
             panic!("Old database schema. This version is not compatible with it.");
         }
+
+        Self::migrate_received_notes_pool(&mut connection).await?;
 
         let r = sqlx::query("SELECT 1 FROM addresses")
             .map(|r: SqliteRow| r.get::<u32, _>(0))
@@ -556,14 +612,15 @@ impl Db {
 
                     sqlx::query(
                         "INSERT INTO received_notes
-                        (address, account, sub_account, id_tx, position, height,
+                        (address, account, sub_account, id_tx, pool, position, height,
                         diversifier, value, rcm, nf, rho, memo, spent)
-                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,'',0)",
+                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,'',0)",
                     )
                     .bind(&received_note.address)
                     .bind(account)
                     .bind(sub_account)
                     .bind(id_tx)
+                    .bind(received_note.pool)
                     .bind(received_note.position)
                     .bind(received_note.height)
                     .bind(received_note.diversifier.as_slice())
@@ -661,5 +718,118 @@ impl Db {
 
     pub fn ufvk(&self) -> &UnifiedFullViewingKey {
         &self.ufvk
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan::POOL_IRONWOOD;
+    use sqlx::Connection;
+
+    /// The pre-NU6.3 `received_notes` schema: no `pool` column, and note positions constrained
+    /// to be unique across every pool.
+    const LEGACY_DDL: &str = "CREATE TABLE received_notes (
+        id_note INTEGER PRIMARY KEY,
+        address TEXT NOT NULL,
+        account INTEGER,
+        sub_account INTEGER,
+        id_tx INTEGER NOT NULL,
+        position INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        diversifier BLOB NOT NULL,
+        value INTEGER NOT NULL,
+        rcm BLOB NOT NULL,
+        nf BLOB NOT NULL UNIQUE,
+        rho BLOB,
+        memo TEXT,
+        spent INTEGER,
+        CONSTRAINT tx_output UNIQUE (position))";
+
+    async fn insert_legacy_note(
+        connection: &mut SqliteConnection,
+        position: u32,
+        nf: &[u8],
+        rho: Option<&[u8]>,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO received_notes
+            (address, account, sub_account, id_tx, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            VALUES ('addr',0,0,1,?1,100,x'00',1000,x'00',?2,?3,'',0)",
+        )
+        .bind(position)
+        .bind(nf)
+        .bind(rho)
+        .execute(&mut *connection)
+        .await?;
+        Ok(())
+    }
+
+    async fn insert_note(
+        connection: &mut SqliteConnection,
+        pool: u8,
+        position: u32,
+        nf: &[u8],
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO received_notes
+            (address, account, sub_account, id_tx, pool, position, height,
+            diversifier, value, rcm, nf, rho, memo, spent)
+            VALUES ('addr',0,0,1,?1,?2,100,x'00',1000,x'00',?3,NULL,'',0)",
+        )
+        .bind(pool)
+        .bind(position)
+        .bind(nf)
+        .execute(&mut *connection)
+        .await?;
+        Ok(())
+    }
+
+    /// The migration must (a) recover each existing note's pool without a rescan and (b) key the
+    /// uniqueness constraint on `(pool, position)`. Ironwood's commitment tree restarts note
+    /// positions from zero at the NU6.3 activation height, so under the legacy
+    /// `UNIQUE (position)` constraint the first Ironwood receives would collide with the
+    /// wallet's low Sapling/Orchard positions and fail the whole scan batch.
+    #[tokio::test]
+    async fn migration_backfills_pools_and_rekeys_the_position_constraint() -> Result<()> {
+        let mut connection = SqliteConnection::connect("sqlite::memory:").await?;
+        sqlx::query(LEGACY_DDL).execute(&mut connection).await?;
+        // `rho` is set only on Orchard-family notes, which is what makes the pool of a
+        // pre-migration row recoverable.
+        insert_legacy_note(&mut connection, 7, b"sapling-nf", None).await?;
+        insert_legacy_note(&mut connection, 9, b"orchard-nf", Some(b"rho")).await?;
+
+        Db::migrate_received_notes_pool(&mut connection).await?;
+
+        let pools: Vec<(Vec<u8>, u8)> = sqlx::query("SELECT nf, pool FROM received_notes")
+            .map(|r: SqliteRow| (r.get(0), r.get(1)))
+            .fetch_all(&mut connection)
+            .await?;
+        assert_eq!(
+            pools,
+            vec![
+                (b"sapling-nf".to_vec(), POOL_SAPLING),
+                (b"orchard-nf".to_vec(), POOL_ORCHARD),
+            ]
+        );
+
+        // An Ironwood note at a position already used by another pool is now accepted...
+        insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf").await?;
+        // ...while a genuine duplicate within one pool is still rejected.
+        assert!(
+            insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf-2")
+                .await
+                .is_err()
+        );
+
+        // Re-running the migration is a no-op.
+        Db::migrate_received_notes_pool(&mut connection).await?;
+        let (count,): (u32,) = sqlx::query_as("SELECT COUNT(*) FROM received_notes")
+            .fetch_one(&mut connection)
+            .await?;
+        assert_eq!(count, 3);
+
+        Ok(())
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -29,11 +29,13 @@ const RECEIVED_NOTES_DDL: &str = "CREATE TABLE IF NOT EXISTS received_notes (
     diversifier BLOB NOT NULL,
     value INTEGER NOT NULL,
     rcm BLOB NOT NULL,
-    nf BLOB NOT NULL UNIQUE,
+    nf BLOB NOT NULL,
     rho BLOB,
     memo TEXT,
-    spent INTEGER,
-    CONSTRAINT tx_output UNIQUE (pool, position))";
+    spent_height INTEGER,
+    CONSTRAINT tx_output UNIQUE (pool, position),
+    CONSTRAINT note_nullifier UNIQUE (pool, nf))";
+const IRONWOOD_REPLAY_KEY: &str = "ironwood_replay_complete";
 
 pub struct Db {
     network: Network,
@@ -41,6 +43,7 @@ pub struct Db {
     ufvk: UnifiedFullViewingKey,
     notify_tx_url: String,
     address_creation_lock: Mutex<()>,
+    scan_lock: Mutex<()>,
 }
 
 impl Db {
@@ -60,6 +63,7 @@ impl Db {
             ufvk: ufvk.clone(),
             notify_tx_url: notify_tx_url.to_string(),
             address_creation_lock: Mutex::new(()),
+            scan_lock: Mutex::new(()),
         })
     }
 
@@ -75,51 +79,70 @@ impl Db {
     /// existing row is recoverable without rescanning: `rho` is only ever set for
     /// Orchard-family notes, so a NULL `rho` means Sapling. No pre-migration row can be
     /// Ironwood — the pool did not exist.
-    async fn migrate_received_notes_pool(connection: &mut SqliteConnection) -> Result<()> {
-        if sqlx::query("SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'pool'")
-            .fetch_optional(&mut *connection)
-            .await?
-            .is_some()
-        {
-            return Ok(());
+    async fn migrate_received_notes_pool(connection: &mut SqliteConnection) -> Result<bool> {
+        let has_pool =
+            sqlx::query("SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'pool'")
+                .fetch_optional(&mut *connection)
+                .await?
+                .is_some();
+        let has_spent_height = sqlx::query(
+            "SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'spent_height'",
+        )
+        .fetch_optional(&mut *connection)
+        .await?
+        .is_some();
+        if has_pool && has_spent_height {
+            return Ok(false);
         }
         log::info!("Migrating received_notes to the pool-aware (NU6.3) schema");
 
         let mut db_transaction = connection.begin().await?;
         let db_tx = db_transaction.acquire().await?;
+        let (before_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM received_notes")
+            .fetch_one(&mut *db_tx)
+            .await?;
         sqlx::query(&RECEIVED_NOTES_DDL.replace("received_notes", "received_notes_new"))
             .execute(&mut *db_tx)
             .await?;
-        sqlx::query(
+        let pool = if has_pool {
+            "pool"
+        } else {
+            "CASE WHEN rho IS NULL THEN ?1 ELSE ?2 END"
+        };
+        let spent_height = if has_spent_height {
+            "spent_height"
+        } else {
+            "CASE WHEN spent IS NULL OR spent = 0 THEN NULL ELSE 0 END"
+        };
+        let copy = format!(
             "INSERT INTO received_notes_new
             (id_note, address, account, sub_account, id_tx, pool, position, height,
-            diversifier, value, rcm, nf, rho, memo, spent)
-            SELECT id_note, address, account, sub_account, id_tx,
-            CASE WHEN rho IS NULL THEN ?1 ELSE ?2 END,
-            position, height, diversifier, value, rcm, nf, rho, memo, spent
-            FROM received_notes",
-        )
-        .bind(POOL_SAPLING)
-        .bind(POOL_ORCHARD)
-        .execute(&mut *db_tx)
-        .await?;
+            diversifier, value, rcm, nf, rho, memo, spent_height)
+            SELECT id_note, address, account, sub_account, id_tx, {pool},
+            position, height, diversifier, value, rcm, nf, rho, memo, {spent_height}
+            FROM received_notes"
+        );
+        let mut copy = sqlx::query(&copy);
+        if !has_pool {
+            copy = copy.bind(POOL_SAPLING).bind(POOL_ORCHARD);
+        }
+        copy.execute(&mut *db_tx).await?;
         sqlx::query("DROP TABLE received_notes")
             .execute(&mut *db_tx)
             .await?;
         sqlx::query("ALTER TABLE received_notes_new RENAME TO received_notes")
             .execute(&mut *db_tx)
             .await?;
+        let (after_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM received_notes")
+            .fetch_one(&mut *db_tx)
+            .await?;
+        anyhow::ensure!(
+            before_count == after_count,
+            "received_notes migration lost rows"
+        );
         db_transaction.commit().await?;
 
-        Ok(())
-    }
-
-    async fn cleanup_stale_data(connection: &mut SqliteConnection) -> Result<()> {
-        sqlx::query("DELETE FROM received_notes WHERE height >=
-            (SELECT MAX(height) FROM blocks)")
-        .execute(connection)
-        .await?;
-        Ok(())
+        Ok(true)
     }
 
     pub async fn new_account(&self, name: &str) -> Result<Account> {
@@ -226,11 +249,11 @@ impl Db {
         confirmations: u32,
     ) -> Result<Vec<AccountBalance>> {
         let mut connection = self.pool.acquire().await?;
-        let confirmed_height = height - confirmations + 1;
+        let confirmed_height = height.saturating_sub(confirmations.saturating_sub(1));
         let sub_accounts = sqlx::query(
             "WITH base AS (SELECT account, address FROM addresses WHERE sub_account = 0), \
-                balances AS (SELECT account, SUM(value) AS total from received_notes WHERE spent IS NULL GROUP BY account), \
-                unlocked_balances AS (SELECT account, SUM(value) AS unlocked from received_notes WHERE spent IS NULL AND height <= ?1 GROUP BY account) \
+                balances AS (SELECT account, SUM(value) AS total from received_notes WHERE spent_height IS NULL GROUP BY account), \
+                unlocked_balances AS (SELECT account, SUM(value) AS unlocked from received_notes WHERE spent_height IS NULL AND height <= ?1 GROUP BY account) \
                 SELECT a.account, a.label, b.total, COALESCE(u.unlocked, 0) AS unlocked, base.address as base_address \
                 FROM addresses a JOIN balances b ON a.account = b.account LEFT JOIN unlocked_balances u ON u.account = a.account JOIN base ON base.account = a.account GROUP BY a.account")
             .bind(confirmed_height)
@@ -305,7 +328,7 @@ impl Db {
         Transfer {
             address,
             amount: value,
-            confirmations: latest_height - height + 1,
+            confirmations: latest_height.saturating_sub(height).saturating_add(1),
             height,
             fee: 0,
             note: memo,
@@ -377,24 +400,88 @@ impl Db {
 
     pub async fn truncate_height(&self, height: u32) -> Result<()> {
         let mut connection = self.pool.acquire().await?;
+        Self::truncate_to_checkpoint(&mut connection, height).await?;
+        Ok(())
+    }
 
-        sqlx::query("DELETE FROM transactions WHERE height >= ?1")
-            .bind(height)
-            .execute(&mut *connection)
+    async fn truncate_to_checkpoint(connection: &mut SqliteConnection, height: u32) -> Result<u32> {
+        let mut transaction = connection.begin().await?;
+        let db_tx = transaction.acquire().await?;
+        let (checkpoint,): (Option<u32>,) = sqlx::query_as(
+            "SELECT COALESCE(
+                (SELECT MAX(height) FROM blocks WHERE height < ?1),
+                (SELECT MIN(height) FROM blocks))",
+        )
+        .bind(height)
+        .fetch_one(&mut *db_tx)
+        .await?;
+        let checkpoint = checkpoint
+            .ok_or_else(|| anyhow::anyhow!("no wallet checkpoint exists below height {height}"))?;
+
+        sqlx::query("DELETE FROM received_notes WHERE height > ?1")
+            .bind(checkpoint)
+            .execute(&mut *db_tx)
             .await?;
-        sqlx::query("DELETE FROM received_notes WHERE height >= ?1")
-            .bind(height)
-            .execute(&mut *connection)
+        sqlx::query("DELETE FROM transactions WHERE height > ?1")
+            .bind(checkpoint)
+            .execute(&mut *db_tx)
             .await?;
-        sqlx::query("DELETE FROM blocks WHERE height >= ?1")
-            .bind(height)
-            .execute(&mut *connection)
+        sqlx::query("DELETE FROM blocks WHERE height > ?1")
+            .bind(checkpoint)
+            .execute(&mut *db_tx)
             .await?;
-        sqlx::query("UPDATE received_notes SET spent = NULL WHERE spent >= ?1")
-            .bind(height)
-            .execute(&mut *connection)
+        sqlx::query("UPDATE received_notes SET spent_height = NULL WHERE spent_height > ?1")
+            .bind(checkpoint)
+            .execute(&mut *db_tx)
             .await?;
 
+        transaction.commit().await?;
+        Ok(checkpoint)
+    }
+
+    pub async fn rewind_for_ironwood(&self, height: u32, hash: &Hash) -> Result<()> {
+        let mut connection = self.pool.acquire().await?;
+        let mut transaction = connection.begin().await?;
+        let db_tx = transaction.acquire().await?;
+
+        sqlx::query("DELETE FROM received_notes WHERE height > ?1")
+            .bind(height)
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query("UPDATE transactions SET value = 0 WHERE height > ?1")
+            .bind(height)
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query("DELETE FROM blocks WHERE height > ?1")
+            .bind(height)
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query("UPDATE received_notes SET spent_height = NULL WHERE spent_height > ?1")
+            .bind(height)
+            .execute(&mut *db_tx)
+            .await?;
+        sqlx::query(
+            "INSERT INTO blocks(height, hash) VALUES (?1, ?2)
+             ON CONFLICT(height) DO UPDATE SET hash = excluded.hash",
+        )
+        .bind(height)
+        .bind(hash.as_slice())
+        .execute(&mut *db_tx)
+        .await?;
+        sqlx::query("INSERT OR REPLACE INTO wallet_metadata(key, value) VALUES (?1, '1')")
+            .bind(IRONWOOD_REPLAY_KEY)
+            .execute(&mut *db_tx)
+            .await?;
+
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn complete_ironwood_replay(&self) -> Result<()> {
+        sqlx::query("INSERT OR REPLACE INTO wallet_metadata(key, value) VALUES (?1, '1')")
+            .bind(IRONWOOD_REPLAY_KEY)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -406,14 +493,7 @@ impl Db {
             .await?
             .is_none()
         {
-            let b = client
-                .get_block(Request::new(BlockId {
-                    height: height as u64,
-                    hash: vec![],
-                }))
-                .await?
-                .into_inner();
-            let hash: Hash = b.hash.try_into().unwrap();
+            let hash = Self::fetch_canonical_block_hash(client, height).await?;
             sqlx::query(
                 "INSERT INTO blocks(hash, height)
             VALUES (?1, ?2)",
@@ -426,22 +506,43 @@ impl Db {
         Ok(())
     }
 
-    pub async fn get_nfs(&self) -> Result<HashMap<[u8; 32], u64>> {
+    pub async fn fetch_canonical_block_hash(client: &mut Client, height: u32) -> Result<Hash> {
+        let block = client
+            .get_block(Request::new(BlockId {
+                height: u64::from(height),
+                hash: vec![],
+            }))
+            .await?
+            .into_inner();
+        anyhow::ensure!(block.height == u64::from(height), "unexpected block height");
+        block.hash.try_into().map_err(|hash: Vec<u8>| {
+            anyhow::anyhow!(
+                "block hash must contain exactly 32 bytes, got {}",
+                hash.len()
+            )
+        })
+    }
+
+    pub async fn get_nfs(&self) -> Result<HashMap<(u8, [u8; 32]), u64>> {
         let mut connection = self.pool.acquire().await?;
-
-        let nfs = sqlx::query("SELECT nf, value FROM received_notes WHERE spent = 0")
-            .map(|row: SqliteRow| {
-                let nf: Vec<u8> = row.get(0);
-                let value: u64 = row.get(1);
-                let nf: Hash = nf.try_into().unwrap();
-                (nf, value)
-            })
-            .fetch_all(&mut *connection)
-            .await?;
-
+        let rows = sqlx::query(
+            "SELECT pool, nf, value FROM received_notes
+                 WHERE spent_height IS NULL OR spent_height = 0",
+        )
+        .fetch_all(&mut *connection)
+        .await?;
         let mut nf_map = HashMap::new();
-        for (nf, value) in nfs {
-            nf_map.insert(nf, value);
+        for row in rows {
+            let pool: u8 = row.try_get(0)?;
+            let nf: Vec<u8> = row.try_get(1)?;
+            let value: u64 = row.try_get(2)?;
+            let nf: Hash = nf.try_into().map_err(|nf: Vec<u8>| {
+                anyhow::anyhow!(
+                    "stored nullifier must contain exactly 32 bytes, got {}",
+                    nf.len()
+                )
+            })?;
+            nf_map.insert((pool, nf), value);
         }
         Ok(nf_map)
     }
@@ -461,8 +562,16 @@ impl Db {
         Ok((ndi, ua))
     }
 
-    pub async fn create(&self) -> Result<bool> {
+    pub async fn create(&self) -> Result<(bool, bool)> {
         let mut connection = self.pool.acquire().await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS wallet_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL)",
+        )
+        .execute(&mut *connection)
+        .await?;
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS blocks (
@@ -508,8 +617,6 @@ impl Db {
             .execute(&mut *connection)
             .await?;
 
-        Self::cleanup_stale_data(&mut connection).await?;
-
         if sqlx::query("SELECT 1 FROM pragma_table_info('received_notes') WHERE name = 'rho'")
             .fetch_optional(&mut *connection)
             .await?
@@ -519,13 +626,18 @@ impl Db {
         }
 
         Self::migrate_received_notes_pool(&mut connection).await?;
+        let ironwood_replay_pending = sqlx::query("SELECT 1 FROM wallet_metadata WHERE key = ?1")
+            .bind(IRONWOOD_REPLAY_KEY)
+            .fetch_optional(&mut *connection)
+            .await?
+            .is_none();
 
         let r = sqlx::query("SELECT 1 FROM addresses")
             .map(|r: SqliteRow| r.get::<u32, _>(0))
             .fetch_optional(&mut *connection)
             .await?;
 
-        Ok(r.is_some())
+        Ok((r.is_some(), ironwood_replay_pending))
     }
 
     pub async fn store_events(&self, events: &[ScanEvent]) -> Result<()> {
@@ -613,8 +725,8 @@ impl Db {
                     sqlx::query(
                         "INSERT INTO received_notes
                         (address, account, sub_account, id_tx, pool, position, height,
-                        diversifier, value, rcm, nf, rho, memo, spent)
-                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,'',0)",
+                        diversifier, value, rcm, nf, rho, memo, spent_height)
+                        VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,'',NULL)",
                     )
                     .bind(&received_note.address)
                     .bind(account)
@@ -637,19 +749,25 @@ impl Db {
                         .await?;
                 }
                 ScanEvent::Spent(spent_note) => {
-                    let (_, is_new) = self.create_tx_if_not_exists(
-                        spent_note.height,
-                        spent_note.txid.as_slice(),
-                        db_tx,
-                    )
-                    .await?;
+                    let (_, is_new) = self
+                        .create_tx_if_not_exists(
+                            spent_note.height,
+                            spent_note.txid.as_slice(),
+                            db_tx,
+                        )
+                        .await?;
                     if is_new {
                         notify_txids.push(spent_note.txid);
                     }
-                    sqlx::query("UPDATE received_notes SET spent = TRUE WHERE nf = ?1")
-                        .bind(spent_note.nf.as_slice())
-                        .execute(&mut *db_tx)
-                        .await?;
+                    sqlx::query(
+                        "UPDATE received_notes SET spent_height = ?3
+                         WHERE pool = ?1 AND nf = ?2",
+                    )
+                    .bind(spent_note.pool)
+                    .bind(spent_note.nf.as_slice())
+                    .bind(spent_note.height)
+                    .execute(&mut *db_tx)
+                    .await?;
                     sqlx::query("UPDATE transactions SET value = value - ?2 WHERE txid = ?1")
                         .bind(spent_note.txid.as_slice())
                         .bind(spent_note.value as i64)
@@ -657,7 +775,8 @@ impl Db {
                         .await?;
                 }
                 ScanEvent::Memo(memo_note) => {
-                    sqlx::query("UPDATE received_notes SET memo = ?2 WHERE nf = ?1")
+                    sqlx::query("UPDATE received_notes SET memo = ?3 WHERE pool = ?1 AND nf = ?2")
+                        .bind(memo_note.pool)
                         .bind(memo_note.nf.as_slice())
                         .bind(&memo_note.memo)
                         .execute(&mut *db_tx)
@@ -719,6 +838,10 @@ impl Db {
     pub fn ufvk(&self) -> &UnifiedFullViewingKey {
         &self.ufvk
     }
+
+    pub async fn lock_scan(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.scan_lock.lock().await
+    }
 }
 
 #[cfg(test)]
@@ -745,6 +868,24 @@ mod tests {
         memo TEXT,
         spent INTEGER,
         CONSTRAINT tx_output UNIQUE (position))";
+
+    const PR63_DDL: &str = "CREATE TABLE received_notes (
+        id_note INTEGER PRIMARY KEY,
+        address TEXT NOT NULL,
+        account INTEGER,
+        sub_account INTEGER,
+        id_tx INTEGER NOT NULL,
+        pool INTEGER NOT NULL,
+        position INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        diversifier BLOB NOT NULL,
+        value INTEGER NOT NULL,
+        rcm BLOB NOT NULL,
+        nf BLOB NOT NULL UNIQUE,
+        rho BLOB,
+        memo TEXT,
+        spent INTEGER,
+        CONSTRAINT tx_output UNIQUE (pool, position))";
 
     async fn insert_legacy_note(
         connection: &mut SqliteConnection,
@@ -775,8 +916,8 @@ mod tests {
         sqlx::query(
             "INSERT INTO received_notes
             (address, account, sub_account, id_tx, pool, position, height,
-            diversifier, value, rcm, nf, rho, memo, spent)
-            VALUES ('addr',0,0,1,?1,?2,100,x'00',1000,x'00',?3,NULL,'',0)",
+            diversifier, value, rcm, nf, rho, memo, spent_height)
+            VALUES ('addr',0,0,1,?1,?2,100,x'00',1000,x'00',?3,NULL,'',NULL)",
         )
         .bind(pool)
         .bind(position)
@@ -800,7 +941,7 @@ mod tests {
         insert_legacy_note(&mut connection, 7, b"sapling-nf", None).await?;
         insert_legacy_note(&mut connection, 9, b"orchard-nf", Some(b"rho")).await?;
 
-        Db::migrate_received_notes_pool(&mut connection).await?;
+        assert!(Db::migrate_received_notes_pool(&mut connection).await?);
 
         let pools: Vec<(Vec<u8>, u8)> = sqlx::query("SELECT nf, pool FROM received_notes")
             .map(|r: SqliteRow| (r.get(0), r.get(1)))
@@ -816,6 +957,7 @@ mod tests {
 
         // An Ironwood note at a position already used by another pool is now accepted...
         insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf").await?;
+        insert_note(&mut connection, POOL_SAPLING, 8, b"ironwood-nf").await?;
         // ...while a genuine duplicate within one pool is still rejected.
         assert!(
             insert_note(&mut connection, POOL_IRONWOOD, 7, b"ironwood-nf-2")
@@ -824,11 +966,181 @@ mod tests {
         );
 
         // Re-running the migration is a no-op.
-        Db::migrate_received_notes_pool(&mut connection).await?;
+        assert!(!Db::migrate_received_notes_pool(&mut connection).await?);
         let (count,): (u32,) = sqlx::query_as("SELECT COUNT(*) FROM received_notes")
             .fetch_one(&mut connection)
             .await?;
-        assert_eq!(count, 3);
+        assert_eq!(count, 4);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pr63_upgrade_rewinds_once_and_preserves_replay_state() -> Result<()> {
+        let path = std::env::temp_dir().join(format!(
+            "zcash-walletd-pr63-upgrade-{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let ufvk = zcash_keys::keys::UnifiedSpendingKey::from_seed(
+            &Network::Main,
+            &[0; 32],
+            zip32::AccountId::ZERO,
+        )?
+        .to_unified_full_viewing_key();
+        let db = Db::new(Network::Main, &path.to_string_lossy(), &ufvk, "").await?;
+        let activation_height = u32::from(
+            Network::Main
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .unwrap(),
+        );
+        let rewind_height = activation_height - 1;
+
+        {
+            let mut connection = db.pool.acquire().await?;
+            sqlx::query(PR63_DDL).execute(&mut *connection).await?;
+            sqlx::query("CREATE TABLE blocks (height INTEGER PRIMARY KEY, hash BLOB NOT NULL)")
+                .execute(&mut *connection)
+                .await?;
+            sqlx::query(
+                "CREATE TABLE addresses (
+                    id_address INTEGER PRIMARY KEY, label TEXT NOT NULL,
+                    account INTEGER NOT NULL, sub_account INTEGER NOT NULL,
+                    address TEXT NOT NULL, diversifier_index INTEGER NOT NULL)",
+            )
+            .execute(&mut *connection)
+            .await?;
+            sqlx::query(
+                "CREATE TABLE transactions (
+                    id_tx INTEGER PRIMARY KEY, txid BLOB NOT NULL UNIQUE,
+                    height INTEGER NOT NULL, value INTEGER NOT NULL)",
+            )
+            .execute(&mut *connection)
+            .await?;
+            sqlx::query("INSERT INTO addresses VALUES (1, '', 0, 0, 'addr', 0)")
+                .execute(&mut *connection)
+                .await?;
+            sqlx::query("INSERT INTO blocks VALUES (?1, x'01'), (?2, x'02')")
+                .bind(rewind_height)
+                .bind(activation_height + 10)
+                .execute(&mut *connection)
+                .await?;
+            sqlx::query(
+                "INSERT INTO transactions VALUES
+                    (1, x'01', ?1, 1000), (2, x'02', ?2, 2000)",
+            )
+            .bind(rewind_height - 1)
+            .bind(activation_height + 5)
+            .execute(&mut *connection)
+            .await?;
+            sqlx::query(
+                "INSERT INTO received_notes
+                (address, account, sub_account, id_tx, pool, position, height,
+                diversifier, value, rcm, nf, rho, memo, spent)
+                VALUES
+                ('addr',0,0,1,2,7,?1,x'00',1000,x'00',
+                    x'0101010101010101010101010101010101010101010101010101010101010101',
+                    x'02','',1),
+                ('addr',0,0,2,3,8,?2,x'00',2000,x'00',
+                    x'0303030303030303030303030303030303030303030303030303030303030303',
+                    x'04','',0)",
+            )
+            .bind(rewind_height - 1)
+            .bind(activation_height + 5)
+            .execute(&mut *connection)
+            .await?;
+        }
+
+        assert_eq!(db.create().await?, (true, true));
+        assert_eq!(db.get_nfs().await?.len(), 2);
+
+        let canonical_hash = [9; 32];
+        db.rewind_for_ironwood(rewind_height, &canonical_hash)
+            .await?;
+
+        let mut connection = db.pool.acquire().await?;
+        let blocks: Vec<(u32, Vec<u8>)> = sqlx::query("SELECT height, hash FROM blocks")
+            .map(|row: SqliteRow| (row.get(0), row.get(1)))
+            .fetch_all(&mut *connection)
+            .await?;
+        assert_eq!(blocks, vec![(rewind_height, canonical_hash.to_vec())]);
+        let transactions: Vec<(u32, i64)> =
+            sqlx::query("SELECT height, value FROM transactions ORDER BY id_tx")
+                .map(|row: SqliteRow| (row.get(0), row.get(1)))
+                .fetch_all(&mut *connection)
+                .await?;
+        assert_eq!(
+            transactions,
+            vec![(rewind_height - 1, 1000), (activation_height + 5, 0)]
+        );
+        let notes: Vec<(u8, u32, Option<u32>)> =
+            sqlx::query("SELECT pool, height, spent_height FROM received_notes ORDER BY id_note")
+                .map(|row: SqliteRow| (row.get(0), row.get(1), row.get(2)))
+                .fetch_all(&mut *connection)
+                .await?;
+        assert_eq!(notes, vec![(POOL_ORCHARD, rewind_height - 1, Some(0))]);
+        drop(connection);
+
+        assert_eq!(db.create().await?, (true, false));
+        assert_eq!(db.get_nfs().await?.len(), 1);
+
+        db.pool.close().await;
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reorg_rewinds_to_an_existing_checkpoint_atomically() -> Result<()> {
+        let mut connection = SqliteConnection::connect("sqlite::memory:").await?;
+        sqlx::query("CREATE TABLE blocks (height INTEGER PRIMARY KEY, hash BLOB NOT NULL)")
+            .execute(&mut connection)
+            .await?;
+        sqlx::query(
+            "CREATE TABLE transactions (
+                id_tx INTEGER PRIMARY KEY, txid BLOB NOT NULL UNIQUE,
+                height INTEGER NOT NULL, value INTEGER NOT NULL)",
+        )
+        .execute(&mut connection)
+        .await?;
+        sqlx::query(
+            "CREATE TABLE received_notes (
+                id_note INTEGER PRIMARY KEY, height INTEGER NOT NULL, spent_height INTEGER)",
+        )
+        .execute(&mut connection)
+        .await?;
+        sqlx::query("INSERT INTO blocks VALUES (100, x'01'), (200, x'02')")
+            .execute(&mut connection)
+            .await?;
+        sqlx::query(
+            "INSERT INTO transactions VALUES
+                (1, x'01', 90, 1), (2, x'02', 120, 1)",
+        )
+        .execute(&mut connection)
+        .await?;
+        sqlx::query(
+            "INSERT INTO received_notes VALUES
+                (1, 90, 120), (2, 120, NULL)",
+        )
+        .execute(&mut connection)
+        .await?;
+
+        assert_eq!(Db::truncate_to_checkpoint(&mut connection, 150).await?, 100);
+        let (block_height,): (u32,) = sqlx::query_as("SELECT MAX(height) FROM blocks")
+            .fetch_one(&mut connection)
+            .await?;
+        assert_eq!(block_height, 100);
+        let transactions: Vec<u32> = sqlx::query("SELECT height FROM transactions")
+            .map(|row: SqliteRow| row.get(0))
+            .fetch_all(&mut connection)
+            .await?;
+        assert_eq!(transactions, vec![90]);
+        let notes: Vec<(u32, Option<u32>)> =
+            sqlx::query("SELECT height, spent_height FROM received_notes")
+                .map(|row: SqliteRow| (row.get(0), row.get(1)))
+                .fetch_all(&mut connection)
+                .await?;
+        assert_eq!(notes, vec![(90, None)]);
+        assert_eq!(Db::truncate_to_checkpoint(&mut connection, 50).await?, 100);
 
         Ok(())
     }

--- a/src/generated/cash.z.wallet.sdk.rpc.rs
+++ b/src/generated/cash.z.wallet.sdk.rpc.rs
@@ -52,6 +52,12 @@ pub struct CompactTx {
     pub outputs: ::prost::alloc::vec::Vec<CompactSaplingOutput>,
     #[prost(message, repeated, tag = "6")]
     pub actions: ::prost::alloc::vec::Vec<CompactOrchardAction>,
+    /// Actions of the Ironwood (NU6.3) bundle. Ironwood reuses Orchard's action encoding and
+    /// keys, but its notes live in a *separate* commitment tree and use the V3 note-plaintext
+    /// lead byte, so they must be trial-decrypted with the Ironwood note-encryption domain and
+    /// positioned against the Ironwood tree. Only populated by versioned-protocol servers.
+    #[prost(message, repeated, tag = "9")]
+    pub ironwood_actions: ::prost::alloc::vec::Vec<CompactOrchardAction>,
 }
 /// CompactSaplingSpend is a Sapling Spend Description as described in 7.3 of the Zcash
 /// protocol specification.
@@ -103,14 +109,21 @@ pub struct BlockId {
 }
 /// BlockRange specifies a series of blocks from start to end inclusive.
 /// Both BlockIDs must be heights; specification by hash is not yet supported.
+///
+/// `poolTypes` selects which value pools the server should include in the returned
+/// compact blocks. It is part of the *versioned* lightwallet-protocol
+/// (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
+/// advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
+/// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
+/// legacy default (Sapling + Orchard only).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockRange {
     #[prost(message, optional, tag = "1")]
     pub start: ::core::option::Option<BlockId>,
     #[prost(message, optional, tag = "2")]
     pub end: ::core::option::Option<BlockId>,
-    #[prost(uint64, tag = "3")]
-    pub spam_filter_threshold: u64,
+    #[prost(enumeration = "PoolType", repeated, tag = "3")]
+    pub pool_types: ::prost::alloc::vec::Vec<i32>,
 }
 /// A TxFilter contains the information needed to identify a particular
 /// transaction: either a block and an index, or a direct transaction hash.
@@ -195,6 +208,20 @@ pub struct LightdInfo {
     /// example: "/MagicBean:4.1.1/"
     #[prost(string, tag = "14")]
     pub zcashd_subversion: ::prost::alloc::string::String,
+    /// Zcash donation UA address
+    #[prost(string, tag = "15")]
+    pub donation_address: ::prost::alloc::string::String,
+    /// name of next pending network upgrade, empty if none scheduled
+    #[prost(string, tag = "16")]
+    pub upgrade_name: ::prost::alloc::string::String,
+    /// height of next pending upgrade, zero if none is scheduled
+    #[prost(uint64, tag = "17")]
+    pub upgrade_height: u64,
+    /// Version of https://github.com/zcash/lightwallet-protocol served by this server.
+    /// Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
+    /// (and hence Ironwood data in compact blocks).
+    #[prost(string, tag = "18")]
+    pub lightwallet_protocol_version: ::prost::alloc::string::String,
 }
 /// TransparentAddressBlockFilter restricts the results to the given address
 /// or block range.
@@ -266,6 +293,9 @@ pub struct TreeState {
     /// orchard commitment tree state
     #[prost(string, tag = "6")]
     pub orchard_tree: ::prost::alloc::string::String,
+    /// ironwood (NU6.3) commitment tree state
+    #[prost(string, tag = "7")]
+    pub ironwood_tree: ::prost::alloc::string::String,
 }
 /// Results are sorted by height, which makes it easy to issue another
 /// request that picks up from where the previous left off.
@@ -298,6 +328,16 @@ pub struct GetAddressUtxosReply {
 pub struct GetAddressUtxosReplyList {
     #[prost(message, repeated, tag = "1")]
     pub address_utxos: ::prost::alloc::vec::Vec<GetAddressUtxosReply>,
+}
+/// An identifier for a Zcash value pool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum PoolType {
+    Invalid = 0,
+    Transparent = 1,
+    Sapling = 2,
+    Orchard = 3,
+    Ironwood = 4,
 }
 #[doc = r" Generated client implementations."]
 pub mod compact_tx_streamer_client {

--- a/src/generated/cash.z.wallet.sdk.rpc.rs
+++ b/src/generated/cash.z.wallet.sdk.rpc.rs
@@ -1,3 +1,13 @@
+/// Information about the state of the chain as of a given block.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChainMetadata {
+    #[prost(uint32, tag = "1")]
+    pub sapling_commitment_tree_size: u32,
+    #[prost(uint32, tag = "2")]
+    pub orchard_commitment_tree_size: u32,
+    #[prost(uint32, tag = "3")]
+    pub ironwood_commitment_tree_size: u32,
+}
 /// CompactBlock is a packaging of ONLY the data from a block that's needed to:
 ///   1. Detect a payment to your shielded Sapling address
 ///   2. Detect a spend of your shielded Sapling notes
@@ -25,6 +35,8 @@ pub struct CompactBlock {
     /// zero or more compact transactions from this block
     #[prost(message, repeated, tag = "7")]
     pub vtx: ::prost::alloc::vec::Vec<CompactTx>,
+    #[prost(message, optional, tag = "8")]
+    pub chain_metadata: ::core::option::Option<ChainMetadata>,
 }
 /// CompactTx contains the minimum information for a wallet to know if this transaction
 /// is relevant to it (either pays to it or spends from it) via shielded elements
@@ -114,8 +126,8 @@ pub struct BlockId {
 /// compact blocks. It is part of the *versioned* lightwallet-protocol
 /// (https://github.com/zcash/lightwallet-protocol): a client MUST verify that the server
 /// advertises a non-empty `LightdInfo.lightwalletProtocolVersion` before setting it, because
-/// a legacy server may reject it or silently misinterpret tag 3. Leave it empty for the
-/// legacy default (Sapling + Orchard only).
+/// a legacy server may reject it or silently misinterpret tag 3. Leave it empty to request
+/// the default shielded pools (Sapling, Orchard, and Ironwood).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BlockRange {
     #[prost(message, optional, tag = "1")]
@@ -218,8 +230,7 @@ pub struct LightdInfo {
     #[prost(uint64, tag = "17")]
     pub upgrade_height: u64,
     /// Version of https://github.com/zcash/lightwallet-protocol served by this server.
-    /// Empty on legacy (<= v0.4.x) servers; a non-empty value is what gates `BlockRange.poolTypes`
-    /// (and hence Ironwood data in compact blocks).
+    /// Empty on legacy servers and some v0.5 implementations.
     #[prost(string, tag = "18")]
     pub lightwallet_protocol_version: ::prost::alloc::string::String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,14 @@ struct Args {
 // pub const NOTIFY_TX_URL: &str = "https://localhost:14142/zcashlikedaemoncallback/tx?cryptoCode=yec&hash=";
 
 use crate::{
-    db::Db, lwd_rpc::compact_tx_streamer_client::CompactTxStreamerClient, monitor::monitor_task,
+    db::Db,
+    lwd_rpc::compact_tx_streamer_client::CompactTxStreamerClient,
+    monitor::monitor_task,
+    scan::{get_latest_height, verify_lightwalletd_capability},
 };
 use serde::Deserialize;
 use zcash_client_backend::keys::UnifiedFullViewingKey;
+use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 #[derive(Deserialize, Debug)]
 pub struct WalletConfig {
@@ -105,12 +109,33 @@ async fn main() -> Result<()> {
     let birth_height = config.birth_height;
     let ufvk = UnifiedFullViewingKey::decode(&network, ufvk)
         .map_err(|_| anyhow!("Invalid Unified Viewing Key"))?;
+    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone()).await?;
+    let tip = get_latest_height(&mut client).await?;
+    verify_lightwalletd_capability(&network, &mut client, tip).await?;
+
     let db = Db::new(network, &config.db_path, &ufvk, &config.notify_tx_url).await?;
-    let db_exists = db.create().await?;
+    let (db_exists, ironwood_replay_pending) = db.create().await?;
     if !db_exists {
         db.new_account("").await?;
     }
-    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone()).await?;
+
+    if ironwood_replay_pending {
+        match network.activation_height(NetworkUpgrade::Nu6_3) {
+            Some(activation_height) => {
+                let activation_height = u32::from(activation_height);
+                if db.get_synced_height().await? >= activation_height {
+                    let rewind_height = birth_height.max(activation_height.saturating_sub(1));
+                    let rewind_hash =
+                        Db::fetch_canonical_block_hash(&mut client, rewind_height).await?;
+                    db.rewind_for_ironwood(rewind_height, &rewind_hash).await?;
+                    info!("Rewound wallet scan to {rewind_height} for Ironwood activation");
+                } else {
+                    db.complete_ironwood_replay().await?;
+                }
+            }
+            None => db.complete_ironwood_replay().await?,
+        }
+    }
     db.fetch_block_hash(&mut client, birth_height).await?;
 
     monitor_task(config.port, config.poll_interval).await;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,17 +1,18 @@
 use std::time::Duration;
 
-#[allow(unreachable_code)]
 pub async fn monitor_task(port: u16, poll_interval: u16) {
     tokio::spawn(async move {
         loop {
             let client = reqwest::Client::new();
-            client
+            if let Err(error) = client
                 .post(format!("http://localhost:{port}/request_scan",))
                 .send()
-                .await?;
+                .await
+            {
+                log::warn!("Failed to request wallet scan: {error}");
+            }
 
             tokio::time::sleep(Duration::from_secs(poll_interval as u64)).await;
         }
-        Ok::<_, anyhow::Error>(())
     });
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -38,4 +38,5 @@ pub const REGTEST: LocalNetwork = LocalNetwork {
     nu6: Some(BlockHeight::from_u32(1)),
     nu6_1: Some(BlockHeight::from_u32(1)),
     nu6_2: Some(BlockHeight::from_u32(1)),
+    nu6_3: Some(BlockHeight::from_u32(1)),
 };

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -2,7 +2,7 @@ use crate::account::AccountBalance;
 use crate::db::Db;
 use crate::lwd_rpc::compact_tx_streamer_client::CompactTxStreamerClient;
 use crate::lwd_rpc::*;
-use crate::scan::{get_latest_height, Decoder, Orchard, Sapling, ScanError};
+use crate::scan::{get_latest_height, Decoders, ScanError};
 use crate::transaction::Transfer;
 use crate::{from_tonic, WalletConfig};
 use anyhow::Result;
@@ -266,19 +266,7 @@ pub async fn request_scan(
         .ok_or(anyhow::anyhow!("Block Hash missing from db"))?;
 
     let nfs = db.get_nfs().await?;
-    let mut sap_dec = ufvk.sapling().map(|fvk| {
-        let nk = fvk.fvk().vk.nk;
-        let ivk = fvk.to_ivk(zip32::Scope::External);
-        let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
-        // TODO: Load nfs
-        Decoder::<Sapling>::new(nk, fvk.clone(), pivk, &nfs)
-    });
-    let mut orc_dec = ufvk.orchard().map(|fvk| {
-        let ivk = fvk.to_ivk(zip32::Scope::External);
-        let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-        // TODO: Load nfs
-        Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, &nfs)
-    });
+    let mut decoders = Decoders::new(ufvk, &nfs);
 
     let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
         .await
@@ -296,8 +284,7 @@ pub async fn request_scan(
         start + 1,
         end,
         &prev_hash,
-        &mut sap_dec,
-        &mut orc_dec,
+        &mut decoders,
     )
     .await;
     match res {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -83,10 +83,7 @@ pub async fn get_accounts(
     db: &State<Db>,
     config: &State<WalletConfig>,
 ) -> Result<Json<GetAccountsResponse>, Debug<anyhow::Error>> {
-    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
-        .await
-        .map_err(from_tonic)?;
-    let latest_height = get_latest_height(&mut client).await?;
+    let latest_height = db.get_synced_height().await?;
     let sub_accounts = db.get_accounts(latest_height, config.confirmations).await?;
     let total_balance: u64 = sub_accounts.iter().map(|sa| sa.balance).sum();
     let total_unlocked_balance: u64 = sub_accounts.iter().map(|sa| sa.unlocked_balance).sum();
@@ -118,10 +115,7 @@ pub async fn get_transaction(
     config: &State<WalletConfig>,
 ) -> Result<Json<GetTransactionByIdResponse>, Debug<anyhow::Error>> {
     let request = request.into_inner();
-    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
-        .await
-        .map_err(from_tonic)?;
-    let latest_height = get_latest_height(&mut client).await?;
+    let latest_height = db.get_synced_height().await?;
     let transfers = db
         .get_transfers_by_txid(
             latest_height,
@@ -161,10 +155,7 @@ pub async fn get_transfers(
 ) -> Result<Json<GetTransfersResponse>, Debug<anyhow::Error>> {
     let request = request.into_inner();
     assert!(request.r#in);
-    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
-        .await
-        .map_err(from_tonic)?;
-    let latest_height = get_latest_height(&mut client).await?;
+    let latest_height = db.get_synced_height().await?;
     let transfers = db
         .get_transfers(
             latest_height,
@@ -211,14 +202,10 @@ pub struct GetHeightResponse {
 #[post("/get_height", data = "<_request>")]
 pub async fn get_height(
     _request: Json<GetHeightRequest>,
-    config: &State<WalletConfig>,
+    db: &State<Db>,
 ) -> Result<Json<GetHeightResponse>, Debug<anyhow::Error>> {
-    let mut client = CompactTxStreamerClient::connect(config.lwd_url.clone())
-        .await
-        .map_err(from_tonic)?;
-    let latest_height = get_latest_height(&mut client).await?;
     let rep = GetHeightResponse {
-        height: latest_height,
+        height: db.get_synced_height().await?,
     };
     Ok(Json(rep))
 }
@@ -246,8 +233,10 @@ pub async fn sync_info(
         .map_err(from_tonic)?
         .into_inner();
     let rep = SyncInfoResponse {
-        target_height: rep.block_height as u32,
-        height: rep.estimated_height as u32,
+        target_height: u32::try_from(rep.block_height)
+            .map_err(|_| anyhow::anyhow!("block height exceeds u32"))?,
+        height: u32::try_from(rep.estimated_height)
+            .map_err(|_| anyhow::anyhow!("estimated height exceeds u32"))?,
     };
     Ok(Json(rep))
 }
@@ -257,6 +246,7 @@ pub async fn request_scan(
     db: &State<Db>,
     config: &State<WalletConfig>,
 ) -> Result<(), Debug<anyhow::Error>> {
+    let _guard = db.lock_scan().await;
     let network = config.network();
     let ufvk = db.ufvk();
     let start = db.get_synced_height().await?;
@@ -294,7 +284,7 @@ pub async fn request_scan(
             match error {
                 ScanError::Reorganization => {
                     let synced_height = db.get_synced_height().await?;
-                    db.truncate_height(synced_height - SAFE_REORG_DISTANCE)
+                    db.truncate_height(synced_height.saturating_sub(SAFE_REORG_DISTANCE))
                         .await
                 }
                 ScanError::Other(error) => Err(error),
@@ -311,11 +301,10 @@ pub async fn request_scan(
 pub const SAFE_REORG_DISTANCE: u32 = 100u32;
 
 #[post("/reorg")]
-pub async fn reorg(
-    db: &State<Db>,
-) -> Result<(), Debug<anyhow::Error>> {
+pub async fn reorg(db: &State<Db>) -> Result<(), Debug<anyhow::Error>> {
+    let _guard = db.lock_scan().await;
     let synced_height = db.get_synced_height().await?;
-    db.truncate_height(synced_height - SAFE_REORG_DISTANCE)
+    db.truncate_height(synced_height.saturating_sub(SAFE_REORG_DISTANCE))
         .await?;
     Ok(())
 }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use orchard::{
     keys::FullViewingKey,
     note::{ExtractedNoteCommitment, Nullifier},
-    note_encryption::{CompactAction, OrchardDomain},
+    note_encryption::{
+        CompactAction, DomainVersion, IronwoodVersion, NoteEncryptionDomain, OrchardVersion,
+    },
     primitives::redpallas::{Signature, SpendAuth},
     Action, Address,
 };
@@ -17,7 +19,7 @@ use sapling_crypto::{
 use thiserror::Error;
 use tonic::{transport::Channel, Request};
 use zcash_address::unified::{self, Encoding};
-use zcash_keys::encoding::AddressCodec;
+use zcash_keys::{encoding::AddressCodec, keys::UnifiedFullViewingKey};
 use zcash_note_encryption::{
     try_compact_note_decryption, try_note_decryption, EphemeralKeyBytes, ShieldedOutput,
 };
@@ -33,10 +35,19 @@ use zcash_protocol::{
 use crate::{
     lwd_rpc::{
         compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
-        CompactOrchardAction, CompactSaplingOutput, TxFilter,
+        CompactOrchardAction, CompactSaplingOutput, Empty, PoolType, TxFilter,
     },
     network::Network, Client, Hash,
 };
+
+/// Pool codes recorded on a received note (and on the `receivers` row derived from it).
+pub const POOL_SAPLING: u8 = 1;
+pub const POOL_ORCHARD: u8 = 2;
+/// Ironwood (NU6.3). Ironwood notes are received at ordinary Orchard addresses — the pool
+/// distinction lives at the bundle / note-version level, not in the address encoding — but
+/// they live in their own commitment tree, so they need their own pool code to keep note
+/// positions unambiguous.
+pub const POOL_IRONWOOD: u8 = 3;
 
 pub async fn get_latest_height(client: &mut CompactTxStreamerClient<Channel>) -> Result<u32> {
     let latest_block_id = client
@@ -47,15 +58,94 @@ pub async fn get_latest_height(client: &mut CompactTxStreamerClient<Channel>) ->
     Ok(latest_height as u32)
 }
 
+/// The `BlockRange.poolTypes` selector to use against this server.
+///
+/// Ironwood actions only ride in compact blocks when they are explicitly requested, and the
+/// field is part of the *versioned* lightwallet-protocol: a client must confirm the server
+/// advertises `lightwalletProtocolVersion` before setting it, because a legacy server may
+/// reject it or misinterpret tag 3. Against a legacy server we send an empty selector and get
+/// the legacy default (Sapling + Orchard) — correct behaviour pre-NU6.3, and the operator
+/// needs an upgraded lightwalletd to see Ironwood receives once NU6.3 activates.
+pub async fn pool_types(client: &mut Client) -> Result<Vec<i32>> {
+    let info = client
+        .get_lightd_info(Request::new(Empty {}))
+        .await?
+        .into_inner();
+    if info.lightwallet_protocol_version.is_empty() {
+        log::warn!(
+            "lightwalletd {} does not advertise a lightwallet-protocol version; \
+             Ironwood (NU6.3) notes cannot be detected. Upgrade the server to scan NU6.3 blocks.",
+            info.version
+        );
+        Ok(vec![])
+    } else {
+        Ok(vec![
+            PoolType::Sapling as i32,
+            PoolType::Orchard as i32,
+            PoolType::Ironwood as i32,
+        ])
+    }
+}
+
+/// The per-pool trial-decryption state carried across a scan.
+pub struct Decoders {
+    pub sapling: Option<Decoder<Sapling>>,
+    pub orchard: Option<Decoder<Orchard>>,
+    pub ironwood: Option<Decoder<Ironwood>>,
+}
+
+impl Decoders {
+    /// Build the per-pool decoders for `ufvk`, seeded with the wallet's known nullifiers.
+    pub fn new(ufvk: &UnifiedFullViewingKey, nfs: &HashMap<Hash, u64>) -> Self {
+        let sapling = ufvk.sapling().map(|fvk| {
+            let nk = fvk.fvk().vk.nk;
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, nfs)
+        });
+        let orchard = ufvk.orchard().map(|fvk| {
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, nfs)
+        });
+        // Ironwood is received at the account's Orchard receivers and derives from the same
+        // Orchard key material — only the note plaintext version and the commitment tree
+        // differ — so its decoder is built from the very same FVK.
+        let ironwood = ufvk.orchard().map(|fvk| {
+            let ivk = fvk.to_ivk(zip32::Scope::External);
+            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
+            Decoder::<Ironwood>::new(fvk.clone(), ivk, pivk, nfs)
+        });
+        Decoders {
+            sapling,
+            orchard,
+            ironwood,
+        }
+    }
+
+    /// Look a nullifier up against both Orchard-family decoders.
+    ///
+    /// Orchard and Ironwood derive nullifiers from the same account key, and a note is nullified
+    /// in whichever bundle owns its pool — an Orchard V2 note in the Orchard bundle, an Ironwood
+    /// V3 note in the Ironwood bundle — so a spend must be matched against both sets regardless
+    /// of which action list it was seen in.
+    fn orchard_family_nf(&self, nf: &Hash) -> Option<u64> {
+        self.orchard
+            .as_ref()
+            .and_then(|d| d.nfs.get(nf).copied())
+            .or_else(|| self.ironwood.as_ref().and_then(|d| d.nfs.get(nf).copied()))
+    }
+}
+
 pub async fn scan(
     network: &Network,
     client: &mut Client,
     start: u32,
     end: u32,
     prev_hash: &Hash,
-    sap_dec: &mut Option<Decoder<Sapling>>,
-    orc_dec: &mut Option<Decoder<Orchard>>,
+    decoders: &mut Decoders,
 ) -> Result<Vec<ScanEvent>, ScanError> {
+    let pool_types = pool_types(client).await.map_err(ScanError::Other)?;
     let tree_state = client
         .get_tree_state(Request::new(BlockId {
             height: start as u64,
@@ -75,7 +165,7 @@ pub async fn scan(
                 height: end as u64,
                 hash: vec![],
             }),
-            spam_filter_threshold: 0,
+            pool_types,
         }))
         .await
         .map_err(|e| ScanError::Other(anyhow::Error::new(e)))?
@@ -83,6 +173,9 @@ pub async fn scan(
     let mut prev_hash = *prev_hash;
     let mut sap_position = get_tree_size(&tree_state.sapling_tree).unwrap();
     let mut orc_position = get_tree_size(&tree_state.orchard_tree).unwrap();
+    // Ironwood has its own commitment tree, so its note positions are tracked separately from
+    // Orchard's. Empty (hence 0) before NU6.3 activates, and on servers that don't serve it.
+    let mut irw_position = get_tree_size(&tree_state.ironwood_tree).unwrap();
 
     let mut events = vec![];
     let mut new_txids = vec![];
@@ -97,7 +190,7 @@ pub async fn scan(
 
         for vtx in block.vtx.iter() {
             let mut found = false;
-            if let Some(sap_dec) = sap_dec {
+            if let Some(sap_dec) = decoders.sapling.as_mut() {
                 for i in vtx.spends.iter() {
                     let nf: &Hash = i.nf.as_slice().try_into().unwrap();
                     if let Some(value) = sap_dec.nfs.get(nf) {
@@ -125,17 +218,22 @@ pub async fn scan(
                 }
             }
 
-            if let Some(orc_dec) = orc_dec {
-                for (vout, a) in vtx.actions.iter().enumerate() {
-                    let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
-                    if let Some(value) = orc_dec.nfs.get(nf) {
-                        events.push(ScanEvent::Spent(SpentNote {
-                            height,
-                            nf: *nf,
-                            txid: vtx.hash.clone().try_into().unwrap(),
-                            value: *value,
-                        }));
-                    }
+            // Orchard and Ironwood actions are structurally identical and share the account's
+            // Orchard keys; they differ in the note-plaintext version (so each needs its own
+            // trial-decryption domain) and in which commitment tree positions them. A note is
+            // nullified in whichever bundle owns its pool, so spends are looked up against both
+            // decoders' nullifier sets.
+            for (vout, a) in vtx.actions.iter().enumerate() {
+                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
+                if let Some(value) = decoders.orchard_family_nf(nf) {
+                    events.push(ScanEvent::Spent(SpentNote {
+                        height,
+                        nf: *nf,
+                        txid: vtx.hash.clone().try_into().unwrap(),
+                        value,
+                    }));
+                }
+                if let Some(orc_dec) = decoders.orchard.as_mut() {
                     if let Some(n) = orc_dec.try_compact_note_decryption(
                         network,
                         height,
@@ -150,6 +248,31 @@ pub async fn scan(
                 }
             }
 
+            for (vout, a) in vtx.ironwood_actions.iter().enumerate() {
+                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
+                if let Some(value) = decoders.orchard_family_nf(nf) {
+                    events.push(ScanEvent::Spent(SpentNote {
+                        height,
+                        nf: *nf,
+                        txid: vtx.hash.clone().try_into().unwrap(),
+                        value,
+                    }));
+                }
+                if let Some(irw_dec) = decoders.ironwood.as_mut() {
+                    if let Some(n) = irw_dec.try_compact_note_decryption(
+                        network,
+                        height,
+                        &vtx.hash,
+                        irw_position + vout as u32,
+                        a,
+                    )? {
+                        irw_dec.add_nf(n.nf, n.value);
+                        events.push(ScanEvent::Received(n));
+                        found = true;
+                    }
+                }
+            }
+
             if found {
                 let txid: Hash = vtx.hash.clone().try_into().unwrap();
                 new_txids.push(WalletTx {
@@ -157,16 +280,18 @@ pub async fn scan(
                     txid,
                     sap_position,
                     orc_position,
+                    irw_position,
                 });
             }
 
             sap_position += vtx.outputs.len() as u32;
             orc_position += vtx.actions.len() as u32;
+            irw_position += vtx.ironwood_actions.len() as u32;
         }
     }
 
     for wtx in new_txids.iter() {
-        let memos = scan_tx(network, client, wtx, sap_dec, orc_dec).await?;
+        let memos = scan_tx(network, client, wtx, decoders).await?;
         for m in memos {
             events.push(ScanEvent::Memo(m));
         }
@@ -180,8 +305,7 @@ pub async fn scan_tx(
     network: &Network,
     client: &mut Client,
     wtx: &WalletTx,
-    sap_dec: &Option<Decoder<Sapling>>,
-    orc_dec: &Option<Decoder<Orchard>>,
+    decoders: &Decoders,
 ) -> Result<Vec<MemoNote>> {
     let mut notes = vec![];
     let raw_tx = client
@@ -195,7 +319,7 @@ pub async fn scan_tx(
     let tx = Transaction::read(&*raw_tx.data, branch_id)?;
     let tx = tx.into_data();
 
-    if let Some(sap_dec) = sap_dec {
+    if let Some(sap_dec) = decoders.sapling.as_ref() {
         if let Some(sapling_bundle) = tx.sapling_bundle() {
             for (vout, o) in sapling_bundle.shielded_outputs().iter().enumerate() {
                 if let Some(note) =
@@ -206,11 +330,24 @@ pub async fn scan_tx(
             }
         }
     }
-    if let Some(orc_dec) = orc_dec {
+    if let Some(orc_dec) = decoders.orchard.as_ref() {
         if let Some(orchard_bundle) = tx.orchard_bundle() {
             for (vout, a) in orchard_bundle.actions().iter().enumerate() {
                 if let Some(note) =
                     orc_dec.try_note_decryption(vout as u32 + wtx.orc_position, a)?
+                {
+                    notes.push(note);
+                }
+            }
+        }
+    }
+    // A V6 transaction carries the Orchard and Ironwood bundles side by side; memos for
+    // Ironwood notes are in the latter, decrypted with the Ironwood domain.
+    if let Some(irw_dec) = decoders.ironwood.as_ref() {
+        if let Some(ironwood_bundle) = tx.ironwood_bundle() {
+            for (vout, a) in ironwood_bundle.actions().iter().enumerate() {
+                if let Some(note) =
+                    irw_dec.try_note_decryption(vout as u32 + wtx.irw_position, a)?
                 {
                     notes.push(note);
                 }
@@ -347,7 +484,7 @@ impl Decode<Sapling> for Decoder<Sapling> {
 
             let note = ReceivedNote {
                 txid: txid.try_into().unwrap(),
-                pool: 1,
+                pool: POOL_SAPLING,
                 position,
                 height,
                 address,
@@ -400,6 +537,122 @@ impl Pool for Orchard {
     type Output = Action<Signature<SpendAuth>>;
 }
 
+/// Ironwood, the shielded pool introduced by NU6.3.
+///
+/// Ironwood reuses Orchard's keys, addresses and action encoding wholesale, so a wallet needs no
+/// new key material and no new address type to receive into it: an Ironwood note is simply
+/// received at an ordinary Orchard receiver. What differs is (a) the note plaintext version —
+/// lead byte `0x03` instead of Orchard's `0x02`, so trial decryption needs the Ironwood domain —
+/// and (b) the commitment tree, which is separate from Orchard's and therefore has its own
+/// note positions. Once NU6.3 activates, payments to an Orchard receiver are *routed to this
+/// pool*, so a wallet that only scans `CompactTx.actions` stops seeing its own incoming
+/// payments.
+pub struct Ironwood;
+
+impl Pool for Ironwood {
+    type Address = Address;
+    type NullifierKey = FullViewingKey;
+    type DiversifierKey = orchard::keys::IncomingViewingKey;
+    type PreparedIncomingViewingKey = orchard::keys::PreparedIncomingViewingKey;
+    type CompactOutput = CompactOrchardAction;
+    type Output = Action<Signature<SpendAuth>>;
+}
+
+/// The account keys shared by the Orchard-family pools, plus the pool code to tag notes with.
+struct OrchardFamilyKeys<'a> {
+    nk: &'a FullViewingKey,
+    dk: &'a orchard::keys::IncomingViewingKey,
+    pivk: &'a orchard::keys::PreparedIncomingViewingKey,
+    pool: u8,
+}
+
+/// Trial-decrypt a compact Orchard-family action under the note-plaintext version `V`
+/// (`OrchardVersion` for the Orchard bundle, `IronwoodVersion` for the Ironwood bundle).
+fn orchard_family_compact_decryption<V: DomainVersion>(
+    keys: &OrchardFamilyKeys<'_>,
+    network: &Network,
+    height: u32,
+    txid: &[u8],
+    position: u32,
+    action: &CompactOrchardAction,
+) -> Result<Option<ReceivedNote>> {
+    let epk: &[u8; 32] = action.ephemeral_key.as_slice().try_into().unwrap();
+    let ca = CompactAction::from_parts(
+        Nullifier::from_bytes(action.nullifier.as_slice().try_into().unwrap()).unwrap(),
+        ExtractedNoteCommitment::from_bytes(action.cmx.as_slice().try_into().unwrap()).unwrap(),
+        EphemeralKeyBytes(*epk),
+        action.ciphertext.as_slice().try_into().unwrap(),
+    );
+    let domain = NoteEncryptionDomain::<V>::for_compact_action(&ca);
+    if let Some((note, address)) = try_compact_note_decryption(&domain, keys.pivk, &ca) {
+        let ua = unified::Receiver::Orchard(address.to_raw_address_bytes());
+        let ua = unified::Address::try_from_items(vec![ua])?;
+        let ua = ua.encode(&network.network_type());
+        let diversifier = *address.diversifier().as_array();
+        let value = note.value().inner();
+        let rcm = *note.rseed().as_bytes();
+        let nf = note.nullifier(keys.nk);
+        let rho = note.rho().to_bytes();
+        let di = orchard_family_diversifier(keys.dk, &address)?;
+
+        let note = ReceivedNote {
+            txid: txid.try_into().unwrap(),
+            pool: keys.pool,
+            position,
+            height,
+            address: ua,
+            diversifier,
+            diversifier_index: di,
+            value,
+            rcm,
+            nf: nf.to_bytes(),
+            rho: Some(rho),
+        };
+        return Ok(Some(note));
+    }
+    Ok(None)
+}
+
+/// Full trial decryption of an Orchard-family action, to recover the note's memo.
+fn orchard_family_note_decryption<V: DomainVersion>(
+    keys: &OrchardFamilyKeys<'_>,
+    action: &Action<Signature<SpendAuth>>,
+) -> Result<Option<MemoNote>> {
+    let domain = NoteEncryptionDomain::<V>::for_action(action);
+    if let Some((note, _address, memo_bytes)) = try_note_decryption(&domain, keys.pivk, action) {
+        let nf = note.nullifier(keys.nk);
+        let memo_note = MemoNote {
+            nf: nf.to_bytes(),
+            memo: memo_text(&memo_bytes)?,
+        };
+        return Ok(Some(memo_note));
+    }
+
+    Ok(None)
+}
+
+fn orchard_family_diversifier(
+    dk: &orchard::keys::IncomingViewingKey,
+    address: &Address,
+) -> Result<Option<u64>> {
+    if let Some(di) = dk.diversifier_index(address) {
+        let di: u64 = di.try_into()?;
+        return Ok(Some(di));
+    }
+    Ok(None)
+}
+
+impl Decoder<Orchard> {
+    fn keys(&self) -> OrchardFamilyKeys<'_> {
+        OrchardFamilyKeys {
+            nk: &self.nk,
+            dk: &self.dk,
+            pivk: &self.pivk,
+            pool: POOL_ORCHARD,
+        }
+    }
+}
+
 impl Decode<Orchard> for Decoder<Orchard> {
     fn try_compact_note_decryption(
         &self,
@@ -409,41 +662,14 @@ impl Decode<Orchard> for Decoder<Orchard> {
         position: u32,
         action: &CompactOrchardAction,
     ) -> Result<Option<ReceivedNote>> {
-        let epk: &[u8; 32] = action.ephemeral_key.as_slice().try_into().unwrap();
-        let ca = CompactAction::from_parts(
-            Nullifier::from_bytes(action.nullifier.as_slice().try_into().unwrap()).unwrap(),
-            ExtractedNoteCommitment::from_bytes(action.cmx.as_slice().try_into().unwrap()).unwrap(),
-            EphemeralKeyBytes(*epk),
-            action.ciphertext.as_slice().try_into().unwrap(),
-        );
-        let domain = OrchardDomain::for_compact_action(&ca);
-        if let Some((note, address)) = try_compact_note_decryption(&domain, &self.pivk, &ca) {
-            let ua = unified::Receiver::Orchard(address.to_raw_address_bytes());
-            let ua = unified::Address::try_from_items(vec![ua])?;
-            let ua = ua.encode(&network.network_type());
-            let diversifier = *address.diversifier().as_array();
-            let value = note.value().inner();
-            let rcm = *note.rseed().as_bytes();
-            let nf = note.nullifier(&self.nk);
-            let rho = note.rho().to_bytes();
-            let di = self.decrypt_diversifier(&address)?;
-
-            let note = ReceivedNote {
-                txid: txid.try_into().unwrap(),
-                pool: 2,
-                position,
-                height,
-                address: ua,
-                diversifier,
-                diversifier_index: di,
-                value,
-                rcm,
-                nf: nf.to_bytes(),
-                rho: Some(rho),
-            };
-            return Ok(Some(note));
-        }
-        Ok(None)
+        orchard_family_compact_decryption::<OrchardVersion>(
+            &self.keys(),
+            network,
+            height,
+            txid,
+            position,
+            action,
+        )
     }
 
     fn try_note_decryption(
@@ -451,26 +677,54 @@ impl Decode<Orchard> for Decoder<Orchard> {
         _position: u32,
         action: &Action<Signature<SpendAuth>>,
     ) -> Result<Option<MemoNote>> {
-        let domain = OrchardDomain::for_action(action);
-        if let Some((note, _address, memo_bytes)) = try_note_decryption(&domain, &self.pivk, action)
-        {
-            let nf = note.nullifier(&self.nk);
-            let memo_note = MemoNote {
-                nf: nf.to_bytes(),
-                memo: memo_text(&memo_bytes)?,
-            };
-            return Ok(Some(memo_note));
-        }
-
-        Ok(None)
+        orchard_family_note_decryption::<OrchardVersion>(&self.keys(), action)
     }
 
     fn decrypt_diversifier(&self, address: &Address) -> Result<Option<u64>> {
-        if let Some(di) = self.dk.diversifier_index(address) {
-            let di: u64 = di.try_into()?;
-            return Ok(Some(di));
+        orchard_family_diversifier(&self.dk, address)
+    }
+}
+
+impl Decoder<Ironwood> {
+    fn keys(&self) -> OrchardFamilyKeys<'_> {
+        OrchardFamilyKeys {
+            nk: &self.nk,
+            dk: &self.dk,
+            pivk: &self.pivk,
+            pool: POOL_IRONWOOD,
         }
-        Ok(None)
+    }
+}
+
+impl Decode<Ironwood> for Decoder<Ironwood> {
+    fn try_compact_note_decryption(
+        &self,
+        network: &Network,
+        height: u32,
+        txid: &[u8],
+        position: u32,
+        action: &CompactOrchardAction,
+    ) -> Result<Option<ReceivedNote>> {
+        orchard_family_compact_decryption::<IronwoodVersion>(
+            &self.keys(),
+            network,
+            height,
+            txid,
+            position,
+            action,
+        )
+    }
+
+    fn try_note_decryption(
+        &self,
+        _position: u32,
+        action: &Action<Signature<SpendAuth>>,
+    ) -> Result<Option<MemoNote>> {
+        orchard_family_note_decryption::<IronwoodVersion>(&self.keys(), action)
+    }
+
+    fn decrypt_diversifier(&self, address: &Address) -> Result<Option<u64>> {
+        orchard_family_diversifier(&self.dk, address)
     }
 }
 
@@ -519,6 +773,7 @@ pub struct WalletTx {
     pub txid: Hash,
     pub sap_position: u32,
     pub orc_position: u32,
+    pub irw_position: u32,
 }
 
 pub fn memo_text(memo_bytes: &[u8]) -> Result<String> {
@@ -557,17 +812,7 @@ mod tests {
             hex::decode("5f03d35ae940bb840564c3b7af7ab72255096d3eca15c910c0e40d0000000000")
                 .unwrap();
         let ufvk = zcash_keys::keys::UnifiedFullViewingKey::decode(&Network::Main, FVK).unwrap();
-        let mut sap_dec = ufvk.sapling().map(|fvk| {
-            let nk = fvk.fvk().vk.nk;
-            let ivk = fvk.to_ivk(zip32::Scope::External);
-            let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, &HashMap::new())
-        });
-        let mut orc_dec = ufvk.orchard().map(|fvk| {
-            let ivk = fvk.to_ivk(zip32::Scope::External);
-            let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, &HashMap::new())
-        });
+        let mut decoders = Decoders::new(&ufvk, &HashMap::new());
 
         let events = scan(
             &Network::Main,
@@ -575,14 +820,19 @@ mod tests {
             2_890_000,
             2_900_000,
             &prev_hash.try_into().unwrap(),
-            &mut sap_dec,
-            &mut orc_dec,
+            &mut decoders,
         )
         .await?;
 
         println!("{events:?}");
 
-        let db = Db::new(Network::Main, "zec-wallet-test.db", &ufvk, "").await?;
+        // Scratch database, recreated on each run: `store_events` is not idempotent (note
+        // nullifiers are UNIQUE), and `Db::new` alone does not build the schema.
+        let db_path = std::env::temp_dir().join("zec-wallet-test.db");
+        let _ = std::fs::remove_file(&db_path);
+        let db = Db::new(Network::Main, &db_path.to_string_lossy(), &ufvk, "").await?;
+        db.create().await?;
+        db.new_account("").await?;
         db.store_events(&events).await?;
 
         Ok(())

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{ensure, Context, Result};
 use orchard::{
     keys::FullViewingKey,
     note::{ExtractedNoteCommitment, Nullifier},
@@ -28,16 +28,17 @@ use zcash_primitives::{
     transaction::Transaction,
 };
 use zcash_protocol::{
-    consensus::{BlockHeight, BranchId, Parameters},
+    consensus::{BlockHeight, BranchId, NetworkUpgrade, Parameters},
     memo::{Memo, MemoBytes},
 };
 
 use crate::{
     lwd_rpc::{
-        compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
-        CompactOrchardAction, CompactSaplingOutput, Empty, PoolType, TxFilter,
+        compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainMetadata,
+        ChainSpec, CompactOrchardAction, CompactSaplingOutput, Empty, TxFilter,
     },
-    network::Network, Client, Hash,
+    network::Network,
+    Client, Hash,
 };
 
 /// Pool codes recorded on a received note (and on the `receivers` row derived from it).
@@ -54,37 +55,121 @@ pub async fn get_latest_height(client: &mut CompactTxStreamerClient<Channel>) ->
         .get_latest_block(Request::new(ChainSpec {}))
         .await?
         .into_inner();
-    let latest_height = latest_block_id.height;
-    Ok(latest_height as u32)
+    u32::try_from(latest_block_id.height).context("latest block height exceeds u32")
 }
 
-/// The `BlockRange.poolTypes` selector to use against this server.
-///
-/// Ironwood actions only ride in compact blocks when they are explicitly requested, and the
-/// field is part of the *versioned* lightwallet-protocol: a client must confirm the server
-/// advertises `lightwalletProtocolVersion` before setting it, because a legacy server may
-/// reject it or misinterpret tag 3. Against a legacy server we send an empty selector and get
-/// the legacy default (Sapling + Orchard) — correct behaviour pre-NU6.3, and the operator
-/// needs an upgraded lightwalletd to see Ironwood receives once NU6.3 activates.
-pub async fn pool_types(client: &mut Client) -> Result<Vec<i32>> {
+fn chain_name_matches(network: &Network, chain_name: &str) -> bool {
+    match network {
+        Network::Main => chain_name.eq_ignore_ascii_case("main"),
+        Network::Regtest => chain_name.eq_ignore_ascii_case("regtest"),
+    }
+}
+
+fn parse_branch_id(branch_id: &str) -> Result<u32> {
+    let branch_id = branch_id.trim();
+    let branch_id = branch_id
+        .strip_prefix("0x")
+        .or_else(|| branch_id.strip_prefix("0X"))
+        .unwrap_or(branch_id);
+    u32::from_str_radix(branch_id, 16)
+        .with_context(|| format!("invalid consensus branch id {branch_id:?}"))
+}
+
+fn validate_tree_sizes(
+    metadata: &ChainMetadata,
+    sapling: u32,
+    orchard: u32,
+    ironwood: u32,
+    height: u32,
+) -> Result<()> {
+    ensure!(
+        metadata.sapling_commitment_tree_size == sapling,
+        "Sapling tree size mismatch at height {height}"
+    );
+    ensure!(
+        metadata.orchard_commitment_tree_size == orchard,
+        "Orchard tree size mismatch at height {height}"
+    );
+    ensure!(
+        metadata.ironwood_commitment_tree_size == ironwood,
+        "Ironwood tree size mismatch at height {height}"
+    );
+    Ok(())
+}
+
+pub async fn verify_lightwalletd_capability(
+    network: &Network,
+    client: &mut Client,
+    height: u32,
+) -> Result<()> {
     let info = client
         .get_lightd_info(Request::new(Empty {}))
         .await?
         .into_inner();
-    if info.lightwallet_protocol_version.is_empty() {
-        log::warn!(
-            "lightwalletd {} does not advertise a lightwallet-protocol version; \
-             Ironwood (NU6.3) notes cannot be detected. Upgrade the server to scan NU6.3 blocks.",
-            info.version
+    ensure!(
+        chain_name_matches(network, info.chain_name.trim()),
+        "lightwalletd chain mismatch: {:?}",
+        info.chain_name
+    );
+    let server_height = u32::try_from(info.block_height).context("block height exceeds u32")?;
+    ensure!(
+        server_height >= height,
+        "lightwalletd is behind requested height {height}"
+    );
+    let expected_branch = u32::from(BranchId::for_height(
+        network,
+        BlockHeight::from_u32(server_height),
+    ));
+    ensure!(
+        parse_branch_id(&info.consensus_branch_id)? == expected_branch,
+        "lightwalletd consensus branch mismatch at height {server_height}"
+    );
+
+    if network.is_nu_active(NetworkUpgrade::Nu6_3, BlockHeight::from_u32(height)) {
+        let block = client
+            .get_block(Request::new(BlockId {
+                height: u64::from(height),
+                hash: vec![],
+            }))
+            .await?
+            .into_inner();
+        ensure!(
+            block.height == u64::from(height),
+            "unexpected capability block height"
         );
-        Ok(vec![])
-    } else {
-        Ok(vec![
-            PoolType::Sapling as i32,
-            PoolType::Orchard as i32,
-            PoolType::Ironwood as i32,
-        ])
+        let metadata = block
+            .chain_metadata
+            .context("lightwalletd did not return chain metadata")?;
+        let tree_state = client
+            .get_tree_state(Request::new(BlockId {
+                height: u64::from(height),
+                hash: vec![],
+            }))
+            .await?
+            .into_inner();
+        ensure!(
+            tree_state.height == u64::from(height),
+            "unexpected capability tree height"
+        );
+        ensure!(
+            chain_name_matches(network, tree_state.network.trim()),
+            "capability tree state is from a different chain"
+        );
+        ensure!(
+            parse_display_hash("capability tree hash", &tree_state.hash)?
+                == parse_hash("capability block hash", &block.hash)?,
+            "capability block and tree state do not match"
+        );
+        validate_tree_sizes(
+            &metadata,
+            get_tree_size(&tree_state.sapling_tree)?,
+            get_tree_size(&tree_state.orchard_tree)?,
+            get_tree_size(&tree_state.ironwood_tree)?,
+            height,
+        )?;
     }
+
+    Ok(())
 }
 
 /// The per-pool trial-decryption state carried across a scan.
@@ -96,17 +181,27 @@ pub struct Decoders {
 
 impl Decoders {
     /// Build the per-pool decoders for `ufvk`, seeded with the wallet's known nullifiers.
-    pub fn new(ufvk: &UnifiedFullViewingKey, nfs: &HashMap<Hash, u64>) -> Self {
+    pub fn new(ufvk: &UnifiedFullViewingKey, nfs: &HashMap<(u8, Hash), u64>) -> Self {
+        let pool_nfs = |pool| {
+            nfs.iter()
+                .filter_map(|((note_pool, nf), value)| {
+                    (*note_pool == pool).then_some((*nf, *value))
+                })
+                .collect::<HashMap<_, _>>()
+        };
+        let sapling_nfs = pool_nfs(POOL_SAPLING);
+        let orchard_nfs = pool_nfs(POOL_ORCHARD);
+        let ironwood_nfs = pool_nfs(POOL_IRONWOOD);
         let sapling = ufvk.sapling().map(|fvk| {
             let nk = fvk.fvk().vk.nk;
             let ivk = fvk.to_ivk(zip32::Scope::External);
             let pivk = sapling_crypto::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, nfs)
+            Decoder::<Sapling>::new(nk, fvk.clone(), pivk, &sapling_nfs)
         });
         let orchard = ufvk.orchard().map(|fvk| {
             let ivk = fvk.to_ivk(zip32::Scope::External);
             let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, nfs)
+            Decoder::<Orchard>::new(fvk.clone(), ivk, pivk, &orchard_nfs)
         });
         // Ironwood is received at the account's Orchard receivers and derives from the same
         // Orchard key material — only the note plaintext version and the commitment tree
@@ -114,7 +209,7 @@ impl Decoders {
         let ironwood = ufvk.orchard().map(|fvk| {
             let ivk = fvk.to_ivk(zip32::Scope::External);
             let pivk = orchard::keys::PreparedIncomingViewingKey::new(&ivk);
-            Decoder::<Ironwood>::new(fvk.clone(), ivk, pivk, nfs)
+            Decoder::<Ironwood>::new(fvk.clone(), ivk, pivk, &ironwood_nfs)
         });
         Decoders {
             sapling,
@@ -122,19 +217,42 @@ impl Decoders {
             ironwood,
         }
     }
+}
 
-    /// Look a nullifier up against both Orchard-family decoders.
-    ///
-    /// Orchard and Ironwood derive nullifiers from the same account key, and a note is nullified
-    /// in whichever bundle owns its pool — an Orchard V2 note in the Orchard bundle, an Ironwood
-    /// V3 note in the Ironwood bundle — so a spend must be matched against both sets regardless
-    /// of which action list it was seen in.
-    fn orchard_family_nf(&self, nf: &Hash) -> Option<u64> {
-        self.orchard
-            .as_ref()
-            .and_then(|d| d.nfs.get(nf).copied())
-            .or_else(|| self.ironwood.as_ref().and_then(|d| d.nfs.get(nf).copied()))
+fn parse_hash(field: &str, bytes: &[u8]) -> Result<Hash> {
+    bytes
+        .try_into()
+        .with_context(|| format!("{field} must be exactly 32 bytes, got {}", bytes.len()))
+}
+
+fn parse_display_hash(field: &str, encoded: &str) -> Result<Hash> {
+    let mut bytes = hex::decode(encoded).with_context(|| format!("invalid {field}"))?;
+    bytes.reverse();
+    parse_hash(field, &bytes)
+}
+
+fn verify_checkpoint_hash(encoded: &str, expected: &Hash) -> Result<(), ScanError> {
+    let actual = parse_display_hash("pre-scan tree hash", encoded)?;
+    if actual != *expected {
+        return Err(ScanError::Reorganization);
     }
+    Ok(())
+}
+
+fn position_with_offset(position: u32, offset: usize, pool: &str) -> Result<u32> {
+    position
+        .checked_add(u32::try_from(offset).context("output count exceeds u32")?)
+        .with_context(|| format!("{pool} note position overflow"))
+}
+
+fn validate_compact_sapling_output(output: &CompactSaplingOutput) -> Result<()> {
+    parse_hash("Sapling commitment", &output.cmu)?;
+    parse_hash("Sapling ephemeral key", &output.epk)?;
+    ensure!(
+        output.ciphertext.len() == 52,
+        "Sapling compact ciphertext must contain 52 bytes"
+    );
+    Ok(())
 }
 
 pub async fn scan(
@@ -145,70 +263,101 @@ pub async fn scan(
     prev_hash: &Hash,
     decoders: &mut Decoders,
 ) -> Result<Vec<ScanEvent>, ScanError> {
-    let pool_types = pool_types(client).await.map_err(ScanError::Other)?;
+    if start > end {
+        return Err(anyhow::anyhow!("invalid scan range {start}..{end}").into());
+    }
+    verify_lightwalletd_capability(network, client, end).await?;
+
+    let tree_height = start
+        .checked_sub(1)
+        .context("cannot scan from block zero")?;
     let tree_state = client
         .get_tree_state(Request::new(BlockId {
-            height: start as u64,
+            height: u64::from(tree_height),
             hash: vec![],
         }))
         .await
         .map_err(|e| ScanError::Other(anyhow::Error::new(e)))?
         .into_inner();
+    if tree_state.height != u64::from(tree_height) {
+        return Err(anyhow::anyhow!("unexpected pre-scan tree height").into());
+    }
+    if !chain_name_matches(network, tree_state.network.trim()) {
+        return Err(anyhow::anyhow!("pre-scan tree state is from a different chain").into());
+    }
+    verify_checkpoint_hash(&tree_state.hash, prev_hash)?;
 
     let mut blocks = client
         .get_block_range(Request::new(BlockRange {
             start: Some(BlockId {
-                height: start as u64,
+                height: u64::from(start),
                 hash: vec![],
             }),
             end: Some(BlockId {
-                height: end as u64,
+                height: u64::from(end),
                 hash: vec![],
             }),
-            pool_types,
+            pool_types: vec![],
         }))
         .await
         .map_err(|e| ScanError::Other(anyhow::Error::new(e)))?
         .into_inner();
     let mut prev_hash = *prev_hash;
-    let mut sap_position = get_tree_size(&tree_state.sapling_tree).unwrap();
-    let mut orc_position = get_tree_size(&tree_state.orchard_tree).unwrap();
-    // Ironwood has its own commitment tree, so its note positions are tracked separately from
-    // Orchard's. Empty (hence 0) before NU6.3 activates, and on servers that don't serve it.
-    let mut irw_position = get_tree_size(&tree_state.ironwood_tree).unwrap();
+    let mut sap_position = get_tree_size(&tree_state.sapling_tree)?;
+    let mut orc_position = get_tree_size(&tree_state.orchard_tree)?;
+    let mut irw_position = get_tree_size(&tree_state.ironwood_tree)?;
 
     let mut events = vec![];
     let mut new_txids = vec![];
-    while let Ok(Some(block)) = blocks.message().await {
-        let height = block.height as u32;
-        let block_prev_hash: Hash = block.prev_hash.try_into().unwrap();
+    let mut expected_height = u64::from(start);
+    let mut last_height = None;
+    while let Some(block) = blocks
+        .message()
+        .await
+        .map_err(|e| ScanError::Other(anyhow::Error::new(e)))?
+    {
+        if block.height != expected_height {
+            return Err(
+                anyhow::anyhow!("expected block {expected_height}, got {}", block.height).into(),
+            );
+        }
+        let height = u32::try_from(block.height).context("block height exceeds u32")?;
+        let block_prev_hash = parse_hash("block previous hash", &block.prev_hash)?;
         if prev_hash != block_prev_hash {
             info!("Reorg at {} {}", block.height, hex::encode(block_prev_hash));
             return Err(ScanError::Reorganization);
         }
-        prev_hash = block.hash.try_into().unwrap();
+        prev_hash = parse_hash("block hash", &block.hash)?;
 
         for vtx in block.vtx.iter() {
+            if !vtx.ironwood_actions.is_empty()
+                && !network.is_nu_active(NetworkUpgrade::Nu6_3, BlockHeight::from_u32(height))
+            {
+                return Err(anyhow::anyhow!("Ironwood actions appeared before NU6.3").into());
+            }
+            let txid = parse_hash("transaction id", &vtx.hash)?;
             let mut found = false;
             if let Some(sap_dec) = decoders.sapling.as_mut() {
                 for i in vtx.spends.iter() {
-                    let nf: &Hash = i.nf.as_slice().try_into().unwrap();
-                    if let Some(value) = sap_dec.nfs.get(nf) {
+                    let nf = parse_hash("Sapling nullifier", &i.nf)?;
+                    if let Some(value) = sap_dec.nfs.get(&nf) {
                         events.push(ScanEvent::Spent(SpentNote {
+                            pool: POOL_SAPLING,
                             height,
-                            nf: *nf,
-                            txid: vtx.hash.clone().try_into().unwrap(),
+                            nf,
+                            txid,
                             value: *value,
                         }));
                     }
                 }
 
                 for (vout, o) in vtx.outputs.iter().enumerate() {
+                    validate_compact_sapling_output(o)?;
                     if let Some(n) = sap_dec.try_compact_note_decryption(
                         network,
                         height,
-                        &vtx.hash,
-                        sap_position + vout as u32,
+                        &txid,
+                        position_with_offset(sap_position, vout, "Sapling")?,
                         o,
                     )? {
                         sap_dec.add_nf(n.nf, n.value);
@@ -218,27 +367,23 @@ pub async fn scan(
                 }
             }
 
-            // Orchard and Ironwood actions are structurally identical and share the account's
-            // Orchard keys; they differ in the note-plaintext version (so each needs its own
-            // trial-decryption domain) and in which commitment tree positions them. A note is
-            // nullified in whichever bundle owns its pool, so spends are looked up against both
-            // decoders' nullifier sets.
-            for (vout, a) in vtx.actions.iter().enumerate() {
-                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
-                if let Some(value) = decoders.orchard_family_nf(nf) {
-                    events.push(ScanEvent::Spent(SpentNote {
-                        height,
-                        nf: *nf,
-                        txid: vtx.hash.clone().try_into().unwrap(),
-                        value,
-                    }));
-                }
-                if let Some(orc_dec) = decoders.orchard.as_mut() {
+            if let Some(orc_dec) = decoders.orchard.as_mut() {
+                for (vout, a) in vtx.actions.iter().enumerate() {
+                    let nf = parse_hash("Orchard nullifier", &a.nullifier)?;
+                    if let Some(value) = orc_dec.nfs.get(&nf) {
+                        events.push(ScanEvent::Spent(SpentNote {
+                            pool: POOL_ORCHARD,
+                            height,
+                            nf,
+                            txid,
+                            value: *value,
+                        }));
+                    }
                     if let Some(n) = orc_dec.try_compact_note_decryption(
                         network,
                         height,
-                        &vtx.hash,
-                        orc_position + vout as u32,
+                        &txid,
+                        position_with_offset(orc_position, vout, "Orchard")?,
                         a,
                     )? {
                         orc_dec.add_nf(n.nf, n.value);
@@ -248,22 +393,23 @@ pub async fn scan(
                 }
             }
 
-            for (vout, a) in vtx.ironwood_actions.iter().enumerate() {
-                let nf: &Hash = a.nullifier.as_slice().try_into().unwrap();
-                if let Some(value) = decoders.orchard_family_nf(nf) {
-                    events.push(ScanEvent::Spent(SpentNote {
-                        height,
-                        nf: *nf,
-                        txid: vtx.hash.clone().try_into().unwrap(),
-                        value,
-                    }));
-                }
-                if let Some(irw_dec) = decoders.ironwood.as_mut() {
+            if let Some(irw_dec) = decoders.ironwood.as_mut() {
+                for (vout, a) in vtx.ironwood_actions.iter().enumerate() {
+                    let nf = parse_hash("Ironwood nullifier", &a.nullifier)?;
+                    if let Some(value) = irw_dec.nfs.get(&nf) {
+                        events.push(ScanEvent::Spent(SpentNote {
+                            pool: POOL_IRONWOOD,
+                            height,
+                            nf,
+                            txid,
+                            value: *value,
+                        }));
+                    }
                     if let Some(n) = irw_dec.try_compact_note_decryption(
                         network,
                         height,
-                        &vtx.hash,
-                        irw_position + vout as u32,
+                        &txid,
+                        position_with_offset(irw_position, vout, "Ironwood")?,
                         a,
                     )? {
                         irw_dec.add_nf(n.nf, n.value);
@@ -274,7 +420,6 @@ pub async fn scan(
             }
 
             if found {
-                let txid: Hash = vtx.hash.clone().try_into().unwrap();
                 new_txids.push(WalletTx {
                     height,
                     txid,
@@ -284,10 +429,23 @@ pub async fn scan(
                 });
             }
 
-            sap_position += vtx.outputs.len() as u32;
-            orc_position += vtx.actions.len() as u32;
-            irw_position += vtx.ironwood_actions.len() as u32;
+            sap_position = position_with_offset(sap_position, vtx.outputs.len(), "Sapling")?;
+            orc_position = position_with_offset(orc_position, vtx.actions.len(), "Orchard")?;
+            irw_position =
+                position_with_offset(irw_position, vtx.ironwood_actions.len(), "Ironwood")?;
         }
+
+        let metadata = block
+            .chain_metadata
+            .as_ref()
+            .context("compact block is missing chain metadata")?;
+        validate_tree_sizes(metadata, sap_position, orc_position, irw_position, height)?;
+        last_height = Some(height);
+        expected_height += 1;
+    }
+
+    if last_height != Some(end) || expected_height != u64::from(end) + 1 {
+        return Err(anyhow::anyhow!("compact block stream ended before block {end}").into());
     }
 
     for wtx in new_txids.iter() {
@@ -315,16 +473,25 @@ pub async fn scan_tx(
         }))
         .await?
         .into_inner();
+    ensure!(
+        raw_tx.height == u64::from(wtx.height),
+        "raw transaction height does not match its compact block"
+    );
     let branch_id = BranchId::for_height(network, BlockHeight::from_u32(wtx.height));
     let tx = Transaction::read(&*raw_tx.data, branch_id)?;
+    ensure!(
+        tx.txid().as_ref() == &wtx.txid,
+        "raw transaction id does not match the compact transaction"
+    );
     let tx = tx.into_data();
 
     if let Some(sap_dec) = decoders.sapling.as_ref() {
         if let Some(sapling_bundle) = tx.sapling_bundle() {
             for (vout, o) in sapling_bundle.shielded_outputs().iter().enumerate() {
-                if let Some(note) =
-                    sap_dec.try_note_decryption(vout as u32 + wtx.sap_position, o)?
-                {
+                if let Some(note) = sap_dec.try_note_decryption(
+                    position_with_offset(wtx.sap_position, vout, "Sapling")?,
+                    o,
+                )? {
                     notes.push(note);
                 }
             }
@@ -333,9 +500,10 @@ pub async fn scan_tx(
     if let Some(orc_dec) = decoders.orchard.as_ref() {
         if let Some(orchard_bundle) = tx.orchard_bundle() {
             for (vout, a) in orchard_bundle.actions().iter().enumerate() {
-                if let Some(note) =
-                    orc_dec.try_note_decryption(vout as u32 + wtx.orc_position, a)?
-                {
+                if let Some(note) = orc_dec.try_note_decryption(
+                    position_with_offset(wtx.orc_position, vout, "Orchard")?,
+                    a,
+                )? {
                     notes.push(note);
                 }
             }
@@ -346,9 +514,10 @@ pub async fn scan_tx(
     if let Some(irw_dec) = decoders.ironwood.as_ref() {
         if let Some(ironwood_bundle) = tx.ironwood_bundle() {
             for (vout, a) in ironwood_bundle.actions().iter().enumerate() {
-                if let Some(note) =
-                    irw_dec.try_note_decryption(vout as u32 + wtx.irw_position, a)?
-                {
+                if let Some(note) = irw_dec.try_note_decryption(
+                    position_with_offset(wtx.irw_position, vout, "Ironwood")?,
+                    a,
+                )? {
                     notes.push(note);
                 }
             }
@@ -364,7 +533,7 @@ pub fn get_tree_size(tree: &str) -> Result<u32> {
     }
     let tree = read_commitment_tree::<DummyNode, _, 32>(&*tree)?;
 
-    Ok(tree.size() as u32)
+    u32::try_from(tree.size()).context("commitment tree size exceeds u32")
 }
 
 pub trait Pool {
@@ -395,12 +564,14 @@ pub struct ReceivedNote {
 
 #[derive(Debug)]
 pub struct MemoNote {
+    pub pool: u8,
     pub nf: Hash,
     pub memo: String,
 }
 
 #[derive(Debug)]
 pub struct SpentNote {
+    pub pool: u8,
     pub height: u32,
     pub nf: Hash,
     pub txid: Hash,
@@ -483,7 +654,7 @@ impl Decode<Sapling> for Decoder<Sapling> {
             let di = self.decrypt_diversifier(&pa)?;
 
             let note = ReceivedNote {
-                txid: txid.try_into().unwrap(),
+                txid: parse_hash("transaction id", txid)?,
                 pool: POOL_SAPLING,
                 position,
                 height,
@@ -509,6 +680,7 @@ impl Decode<Sapling> for Decoder<Sapling> {
         if let Some((note, _pa, memo_bytes)) = try_note_decryption(&domain, &self.pivk, output) {
             let nf = note.nf(&self.nk, position as u64);
             let memo_note = MemoNote {
+                pool: POOL_SAPLING,
                 nf: nf.0,
                 memo: memo_text(&memo_bytes)?,
             };
@@ -576,13 +748,21 @@ fn orchard_family_compact_decryption<V: DomainVersion>(
     position: u32,
     action: &CompactOrchardAction,
 ) -> Result<Option<ReceivedNote>> {
-    let epk: &[u8; 32] = action.ephemeral_key.as_slice().try_into().unwrap();
-    let ca = CompactAction::from_parts(
-        Nullifier::from_bytes(action.nullifier.as_slice().try_into().unwrap()).unwrap(),
-        ExtractedNoteCommitment::from_bytes(action.cmx.as_slice().try_into().unwrap()).unwrap(),
-        EphemeralKeyBytes(*epk),
-        action.ciphertext.as_slice().try_into().unwrap(),
-    );
+    let nullifier_bytes = parse_hash("Orchard-family nullifier", &action.nullifier)?;
+    let nullifier = Option::<Nullifier>::from(Nullifier::from_bytes(&nullifier_bytes))
+        .context("invalid Orchard-family nullifier")?;
+    let commitment_bytes = parse_hash("Orchard-family commitment", &action.cmx)?;
+    let commitment = Option::<ExtractedNoteCommitment>::from(ExtractedNoteCommitment::from_bytes(
+        &commitment_bytes,
+    ))
+    .context("invalid Orchard-family commitment")?;
+    let epk = parse_hash("Orchard-family ephemeral key", &action.ephemeral_key)?;
+    let ciphertext = action
+        .ciphertext
+        .as_slice()
+        .try_into()
+        .context("Orchard-family compact ciphertext must contain 52 bytes")?;
+    let ca = CompactAction::from_parts(nullifier, commitment, EphemeralKeyBytes(epk), ciphertext);
     let domain = NoteEncryptionDomain::<V>::for_compact_action(&ca);
     if let Some((note, address)) = try_compact_note_decryption(&domain, keys.pivk, &ca) {
         let ua = unified::Receiver::Orchard(address.to_raw_address_bytes());
@@ -596,7 +776,7 @@ fn orchard_family_compact_decryption<V: DomainVersion>(
         let di = orchard_family_diversifier(keys.dk, &address)?;
 
         let note = ReceivedNote {
-            txid: txid.try_into().unwrap(),
+            txid: parse_hash("transaction id", txid)?,
             pool: keys.pool,
             position,
             height,
@@ -622,6 +802,7 @@ fn orchard_family_note_decryption<V: DomainVersion>(
     if let Some((note, _address, memo_bytes)) = try_note_decryption(&domain, keys.pivk, action) {
         let nf = note.nullifier(keys.nk);
         let memo_note = MemoNote {
+            pool: keys.pool,
             nf: nf.to_bytes(),
             memo: memo_text(&memo_bytes)?,
         };
@@ -797,43 +978,187 @@ pub enum ScanError {
 
 #[cfg(test)]
 mod tests {
-    use crate::db::Db;
-
     use super::*;
     use anyhow::Result;
 
     const FVK: &str = "uview1s5ranpd74zd2pseylw0fmt0cnudf9765mwjjd9mqf8tvjq2nlw9vgypzqayfvs7aeedguwl4r7exz50nrw6llfs3n9xfd4sm2slaay7smysc4yjyuwu3z7n5ccvyw70qkw28yt6xwra6c8d20ewpjeqq4enmftyly3fmn78hwwkyffp2y4x2vk8050vcly8y5fuse5s9e5j4wmwuldemxahrp4zrgatj63mnpqlpacvcudqfsm5ee29pj8lr5wt93eyrx3fwa64m6505cge6n46c7eqw59e0n3m9rmsntcflfmu9wyjgfk2pmjf4npkml93vyq0fps2rh4mdwpz4ld059m6mamjht99j7sdypwx52lj6lvrfgwja4uf7qy2g8d6gkmvkh7u4dksq5gazxvye4gtwfgwmuygg2sqmkkf4fjd3ymf0mq99rhf0trsl0lpddw64r4n7jj7mxy6fcpj64vkx0pre2lla9p8nknrt2c33zy3vaczd";
 
-    #[tokio::test]
-    async fn test() -> Result<()> {
-        let mut client = CompactTxStreamerClient::connect("https://zec.rocks".to_string()).await?;
+    #[test]
+    fn compact_fields_are_validated_before_decryption() {
+        let output = CompactSaplingOutput {
+            cmu: vec![0; 32],
+            epk: vec![0; 31],
+            ciphertext: vec![0; 52],
+        };
+        assert!(validate_compact_sapling_output(&output).is_err());
 
-        let prev_hash =
-            hex::decode("5f03d35ae940bb840564c3b7af7ab72255096d3eca15c910c0e40d0000000000")
-                .unwrap();
+        let action = CompactOrchardAction {
+            nullifier: vec![0; 31],
+            cmx: vec![0; 32],
+            ephemeral_key: vec![0; 32],
+            ciphertext: vec![0; 52],
+        };
+        let ufvk = zcash_keys::keys::UnifiedFullViewingKey::decode(&Network::Main, FVK).unwrap();
+        let decoder = Decoders::new(&ufvk, &HashMap::new()).orchard.unwrap();
+        assert!(decoder
+            .try_compact_note_decryption(&Network::Main, 1, &[0; 32], 0, &action)
+            .is_err());
+    }
+
+    #[test]
+    fn nullifiers_are_scoped_by_pool() {
+        let ufvk = zcash_keys::keys::UnifiedFullViewingKey::decode(&Network::Main, FVK).unwrap();
+        let decoders = Decoders::new(
+            &ufvk,
+            &HashMap::from([
+                ((POOL_SAPLING, [1; 32]), 1),
+                ((POOL_ORCHARD, [2; 32]), 2),
+                ((POOL_IRONWOOD, [3; 32]), 3),
+            ]),
+        );
+
+        assert_eq!(decoders.sapling.unwrap().nfs, HashMap::from([([1; 32], 1)]));
+        assert_eq!(decoders.orchard.unwrap().nfs, HashMap::from([([2; 32], 2)]));
+        assert_eq!(
+            decoders.ironwood.unwrap().nfs,
+            HashMap::from([([3; 32], 3)])
+        );
+    }
+
+    #[test]
+    fn ironwood_v3_notes_use_the_ironwood_domain() {
+        use orchard::{
+            keys::{Scope, SpendingKey},
+            note::{Note, NoteVersion, RandomSeed, Rho},
+            note_encryption::{IronwoodDomain, IronwoodNoteEncryption},
+            value::NoteValue,
+        };
+        use zcash_note_encryption::Domain;
+
+        let spending_key = (0u32..)
+            .find_map(|counter| {
+                let mut bytes = [0; 32];
+                bytes[..4].copy_from_slice(&counter.to_le_bytes());
+                Option::<SpendingKey>::from(SpendingKey::from_bytes(bytes))
+            })
+            .unwrap();
+        let fvk = FullViewingKey::from(&spending_key);
+        let recipient = fvk.address_at(0u32, Scope::External);
+
+        let mut nf_bytes = [0; 32];
+        nf_bytes[0] = 1;
+        let nf_old = Option::<Nullifier>::from(Nullifier::from_bytes(&nf_bytes)).unwrap();
+        let rho = Option::<Rho>::from(Rho::from_bytes(&nf_old.to_bytes())).unwrap();
+        let note = (0u32..)
+            .find_map(|counter| {
+                let mut bytes = [0; 32];
+                bytes[..4].copy_from_slice(&counter.to_le_bytes());
+                let rseed = Option::<RandomSeed>::from(RandomSeed::from_bytes(bytes, &rho))?;
+                Option::<Note>::from(Note::from_parts(
+                    recipient,
+                    NoteValue::from_raw(123_456),
+                    rho,
+                    rseed,
+                    NoteVersion::V3,
+                ))
+            })
+            .unwrap();
+        let cmx = ExtractedNoteCommitment::from(note.commitment());
+        let encryptor =
+            IronwoodNoteEncryption::new(Some(fvk.to_ovk(Scope::External)), note, [0; 512]);
+        let ephemeral_key = IronwoodDomain::epk_bytes(encryptor.epk());
+        let ciphertext = encryptor.encrypt_note_plaintext();
+        let action = CompactOrchardAction {
+            nullifier: nf_old.to_bytes().to_vec(),
+            cmx: cmx.to_bytes().to_vec(),
+            ephemeral_key: ephemeral_key.0.to_vec(),
+            ciphertext: ciphertext[..52].to_vec(),
+        };
+
+        let ivk = fvk.to_ivk(Scope::External);
+        let orchard_decoder = Decoder::<Orchard>::new(
+            fvk.clone(),
+            ivk.clone(),
+            orchard::keys::PreparedIncomingViewingKey::new(&ivk),
+            &HashMap::new(),
+        );
+        let ironwood_decoder = Decoder::<Ironwood>::new(
+            fvk,
+            ivk.clone(),
+            orchard::keys::PreparedIncomingViewingKey::new(&ivk),
+            &HashMap::new(),
+        );
+        let txid = [9; 32];
+
+        assert!(orchard_decoder
+            .try_compact_note_decryption(&Network::Main, 3_428_143, &txid, 7, &action)
+            .unwrap()
+            .is_none());
+        let received = ironwood_decoder
+            .try_compact_note_decryption(&Network::Main, 3_428_143, &txid, 7, &action)
+            .unwrap()
+            .unwrap();
+        assert_eq!(received.pool, POOL_IRONWOOD);
+        assert_eq!(received.value, 123_456);
+        assert_eq!(received.position, 7);
+    }
+
+    #[test]
+    fn chain_metadata_mismatch_is_rejected() {
+        let metadata = ChainMetadata {
+            sapling_commitment_tree_size: 10,
+            orchard_commitment_tree_size: 20,
+            ironwood_commitment_tree_size: 30,
+        };
+        assert!(validate_tree_sizes(&metadata, 10, 20, 30, 1).is_ok());
+        assert!(validate_tree_sizes(&metadata, 10, 20, 29, 1).is_err());
+    }
+
+    #[test]
+    fn checkpoint_hash_mismatch_is_a_reorganization() {
+        let mut display_hash = [1; 32];
+        display_hash.reverse();
+        assert!(verify_checkpoint_hash(&hex::encode(display_hash), &[1; 32]).is_ok());
+        assert!(matches!(
+            verify_checkpoint_hash(&hex::encode(display_hash), &[2; 32]),
+            Err(ScanError::Reorganization)
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires a live public lightwalletd"]
+    async fn live_ironwood_scan() -> Result<()> {
+        let mut client = CompactTxStreamerClient::connect("https://zec.rocks".to_string()).await?;
+        let start = u32::from(
+            Network::Main
+                .activation_height(NetworkUpgrade::Nu6_3)
+                .context("mainnet NU6.3 activation is not configured")?,
+        );
+        let end = start
+            .checked_add(9)
+            .context("live scan range overflow")?
+            .min(get_latest_height(&mut client).await?);
+        let previous = client
+            .get_block(Request::new(BlockId {
+                height: u64::from(start - 1),
+                hash: vec![],
+            }))
+            .await?
+            .into_inner();
+        let prev_hash = parse_hash("previous block hash", &previous.hash)?;
         let ufvk = zcash_keys::keys::UnifiedFullViewingKey::decode(&Network::Main, FVK).unwrap();
         let mut decoders = Decoders::new(&ufvk, &HashMap::new());
 
         let events = scan(
             &Network::Main,
             &mut client,
-            2_890_000,
-            2_900_000,
-            &prev_hash.try_into().unwrap(),
+            start,
+            end,
+            &prev_hash,
             &mut decoders,
         )
         .await?;
-
-        println!("{events:?}");
-
-        // Scratch database, recreated on each run: `store_events` is not idempotent (note
-        // nullifiers are UNIQUE), and `Db::new` alone does not build the schema.
-        let db_path = std::env::temp_dir().join("zec-wallet-test.db");
-        let _ = std::fs::remove_file(&db_path);
-        let db = Db::new(Network::Main, &db_path.to_string_lossy(), &ufvk, "").await?;
-        db.create().await?;
-        db.new_account("").await?;
-        db.store_events(&events).await?;
+        assert!(matches!(events.last(), Some(ScanEvent::Block(height, _)) if *height == end));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This is a focused follow-up to #63, built directly on its current head (`c40e442`). It keeps that PR's Ironwood scanner, dependency choices, protobuf build path, and existing generated gRPC client. The intended review range is [`c40e442...3c91ade`](https://github.com/ruzcash/zcash-walletd/compare/c40e442...3c91ade) (two commits).

The follow-up adds validation and persistence safeguards needed by a long-running payment service, and makes wallet-facing progress correspond to blocks that have actually been committed to the wallet database.

## Why this follow-up is needed

Ironwood introduces a separate commitment tree and nullifier domain while reusing Orchard receiver/key material. A payment service must therefore keep pool-local positions and nullifiers distinct, migrate an existing wallet without losing notes, and avoid reporting confirmations from a remote tip that the wallet has not persisted yet.

The changes below are limited to those invariants and to validation of data received from the configured lightwallet server. They do not replace the Ironwood implementation from #63.

## Changes

- Validate the configured chain and consensus branch, requested compact-block range, block linkage, hash and compact-field lengths, per-pool tree positions, and raw transaction identity before persisting scan results.
- Detect Ironwood capability from the returned chain metadata and tree state rather than from a server vendor string.
- Scope stored note positions and nullifiers by value pool, and migrate both the legacy schema and the schema introduced by #63 in place while preserving rows.
- Store spend heights so a reorganization can restore spends. Legacy spent rows whose height cannot be reconstructed retain an explicit replay sentinel.
- Serialize scan and reorg operations and perform the activation replay atomically.
- Perform a one-time replay from the block before NU6.3 when an existing wallet has already scanned past activation without Ironwood support. A persisted marker makes the replay idempotent across restarts.
- Derive balances, transfers, confirmations, and `get_height` from the persisted wallet checkpoint. The historical `sync_info` field mapping used by existing payment clients is preserved.
- Keep the monitor alive after transient startup or request failures.

The generated Rust file is the project's existing client generated from the local protobufs. This follow-up only adds the official `ChainMetadata` fields used for validation; it does not introduce a second client or a parallel scanner.

## Upgrade behavior

Existing databases are migrated automatically. Operators should still take a database backup before upgrading.

If the wallet is already beyond NU6.3, the first successful start rewinds to `max(birth_height, NU6.3 activation - 1)` and records the replay marker in the same database operation. Subsequent starts do not repeat that rewind.

## Verification

- `cargo test --locked --offline` — 8 passed, 1 ignored live test
- `cargo clippy --locked --offline --all-targets -- -D warnings`
- `git diff --check c40e442..3c91ade`
- ignored mainnet canary against `https://zec.rocks`
- file-backed regression test covering a #63-schema migration, activation rewind, replay state, and idempotent second start

### Mainnet BTCPay E2E

The code was exercised in Docker with BTCPay Server 2.2.1 and the companion Zcash plugin from btcpay-zcash/btcpayserver-zcash-plugin#8.

- Transaction [`15f7c763…d1057ab`](https://cipherscan.app/tx/15f7c763d1f5e7a02a6ff86b979b195b82f9958d3fa2a1ac007ee5b32d1057ab) was detected as a 4,060-zatoshi receive.
- The wallet database stored the note in pool `3` (Ironwood), at account `0` / subaddress `6`.
- BTCPay moved the invoice through processing and settled it after the configured two confirmations.
- After deploying final walletd head `3c91ade`, two starts reopened the same database without repeating the activation rewind; the note remained available, database `PRAGMA quick_check` returned `ok`, and BTCPay remained available.

## Dependency and review scope

This PR is stacked on #63. Until #63 is merged, GitHub's diff against `main` also includes that PR's commit. Please review the linked two-commit range above; I will rebase this follow-up after #63 is merged or updated.

